### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0](https://github.com/Quantumlyy/osdp-rs/compare/v0.1.22...v0.2.0) - 2026-05-04
+
+### Added
+
+- Add ascii utils
+
+### Documentation
+
+- Docs gen
+
+### Testing
+
+- Property + integration coverage; rewrite README
+
+### V0.2.0
+
+- Rewrite for OSDP v2.2 compliance


### PR DESCRIPTION



## 🤖 New release

* `osdp`: 0.1.22 -> 0.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/Quantumlyy/osdp-rs/compare/v0.1.22...v0.2.0) - 2026-05-04

### Added

- Add ascii utils

### Documentation

- Docs gen

### Testing

- Property + integration coverage; rewrite README

### V0.2.0

- Rewrite for OSDP v2.2 compliance
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).