### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1](https://github.com/Quantumlyy/osdp-rs/compare/v0.2.0...v0.2.1) - 2026-05-04
+
+### Changed
+
+- *(cipher)* Construct complement ICV functionally
+
+### Testing
+
+- *(cipher)* Derive test keys/IVs via computed fixture
+
 ## [0.2.0](https://github.com/Quantumlyy/osdp-rs/compare/v0.1.22...v0.2.0) - 2026-05-04
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "osdp"
-version = "0.2.0"
+version = "0.2.1"
 description = "Pure-Rust, no_std-friendly implementation of the SIA Open Supervised Device Protocol (OSDP) v2.2"
 license = "BSD-3-Clause"
 homepage = "https://github.com/Quantumlyy/osdp-rs/blob/main/README.md"


### PR DESCRIPTION



## 🤖 New release

* `osdp`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/Quantumlyy/osdp-rs/compare/v0.2.0...v0.2.1) - 2026-05-04

### Changed

- *(cipher)* Construct complement ICV functionally

### Testing

- *(cipher)* Derive test keys/IVs via computed fixture
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).