### PR TITLE
Tighten session, ACU, and codec error paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["embedded", "no-std", "network-programming", "parser-implementatio
 default = ["std", "secure-channel"]
 std = ["alloc"]
 alloc = []
-secure-channel = ["dep:aes", "dep:cbc", "dep:cipher", "dep:subtle"]
+secure-channel = ["dep:aes", "dep:cbc", "dep:cipher", "dep:subtle", "dep:zeroize"]
 embedded-io = ["dep:embedded-io"]
 embedded-io-async = ["dep:embedded-io-async"]
 defmt = ["dep:defmt"]
@@ -28,6 +28,7 @@ aes = { version = "0.8", default-features = false, optional = true }
 cbc = { version = "0.1", default-features = false, optional = true }
 cipher = { version = "0.4", default-features = false, optional = true }
 subtle = { version = "2.6", default-features = false, optional = true }
+zeroize = { version = "1.8", default-features = false, features = ["derive"], optional = true }
 
 embedded-io = { version = "0.6", optional = true }
 embedded-io-async = { version = "0.6", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ secure-channel = ["dep:aes", "dep:cbc", "dep:cipher", "dep:subtle", "dep:zeroize
 embedded-io = ["dep:embedded-io"]
 embedded-io-async = ["dep:embedded-io-async"]
 defmt = ["dep:defmt"]
+# Internal: turn rustdoc Mermaid code blocks into rendered SVG via aquamarine.
+# Enabled by docs.rs (see [package.metadata.docs.rs]); local `cargo doc`
+# users can pass `--features _docs` to get the same rendering.
+_docs = ["dep:aquamarine"]
 
 [dependencies]
 num_enum = { version = "0.7", default-features = false }
@@ -34,9 +38,15 @@ embedded-io = { version = "0.6", optional = true }
 embedded-io-async = { version = "0.6", optional = true }
 defmt = { version = "0.3", optional = true }
 
+aquamarine = { version = "0.6", optional = true }
+
 [dev-dependencies]
 proptest = "1.5"
 
 [lib]
 name = "osdp"
 path = "src/lib.rs"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/README.md
+++ b/README.md
@@ -19,13 +19,53 @@ Security Industry Association's
 - **Type-state secure session** — invalid SCS sequences (e.g. sending
   `SCS_15` before `SCS_14`) are *compile* errors, not runtime errors.
 
+## Architecture
+
+```mermaid
+flowchart TB
+    APP([Application])
+    subgraph drivers["driver — high-level state machines"]
+        ACU[acu::Acu]
+        PD[pd::Pd]
+    end
+    subgraph messages["typed messages"]
+        CMD[command]
+        REP[reply]
+        MP[multipart]
+    end
+    subgraph wire["wire layer"]
+        PKT[packet]
+        SEC["secure (Annex D)"]
+    end
+    TR[transport]
+    APP --> drivers
+    drivers --> messages
+    drivers --> wire
+    drivers --> TR
+    messages --> wire
+    wire --> TR
+```
+
+The Annex D.4 secure-channel handshake is fully type-stated:
+
+```mermaid
+stateDiagram-v2
+    [*] --> Disconnected: Session::new(scbk)
+    Disconnected --> Challenged: challenge(RND.A)
+    Challenged --> Cryptogrammed: receive_ccrypt(ccrypt) ✔
+    Challenged --> Disconnected: receive_ccrypt(ccrypt) ✘
+    Cryptogrammed --> Secure: confirm_rmac_i(mac) ✔
+    Cryptogrammed --> Disconnected: confirm_rmac_i(mac) ✘
+    Secure --> Secure: mac() / verify()
+```
+
 ## Crate features
 
 | Feature | Default | Pulls in | Purpose |
 |---|---|---|---|
 | `std` | ✓ | std + alloc | desktop usage |
 | `alloc` | ✓ (via `std`) | alloc | `Vec`/`Box`-using paths |
-| `secure-channel` | ✓ | aes, cbc, cipher, subtle | Annex D AES-128 + MAC |
+| `secure-channel` | ✓ | aes, cbc, cipher, subtle, zeroize | Annex D AES-128 + MAC |
 | `embedded-io` | | embedded-io | sync byte-stream transport |
 | `embedded-io-async` | | embedded-io-async | async byte-stream transport |
 | `defmt` | | defmt | structured logging on embedded |
@@ -142,7 +182,7 @@ loopback that exercises SQN cycling, see `examples/loopback_poll.rs`.
 ## Testing
 
 ```sh
-cargo test                              # 71 unit + 14 integration tests
+cargo test                              # 173 unit + 14 integration tests
 cargo test --no-default-features        # `no_std` slice still compiles
 cargo clippy --all-targets --all-features
 cargo run --example loopback_poll

--- a/examples/loopback_poll.rs
+++ b/examples/loopback_poll.rs
@@ -21,11 +21,6 @@ impl PdHandler for AlwaysAck {
     }
 }
 
-fn shuffle(from: &mut VecTransport, to: &mut VecTransport) {
-    let bytes: Vec<u8> = from.outgoing.drain(..).collect();
-    to.incoming.extend(bytes);
-}
-
 fn main() {
     let mut acu = Acu::new(VecTransport::new(), SystemClock::new());
     let mut pd = Pd::new(VecTransport::new(), SystemClock::new(), 0x05, AlwaysAck);
@@ -45,13 +40,13 @@ fn main() {
         );
 
         // Ferry ACU outgoing → PD incoming.
-        shuffle(acu.transport(), pd.transport());
+        acu.transport().shuffle_to(pd.transport());
 
         // PD processes the packet and queues its reply.
         pd.poll_once().expect("pd poll");
 
         // Ferry PD outgoing → ACU incoming.
-        shuffle(pd.transport(), acu.transport());
+        pd.transport().shuffle_to(acu.transport());
 
         // ACU reads its reply.
         match acu.receive(&mut state) {

--- a/src/command/abort.rs
+++ b/src/command/abort.rs
@@ -26,3 +26,22 @@ impl Abort {
         Ok(Self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_empty() {
+        assert!(Abort.encode().unwrap().is_empty());
+        assert_eq!(Abort::decode(&[]).unwrap(), Abort);
+    }
+
+    #[test]
+    fn decode_rejects_payload() {
+        assert!(matches!(
+            Abort::decode(&[0xFF]),
+            Err(Error::MalformedPayload { code: 0xA2, .. })
+        ));
+    }
+}

--- a/src/command/abort.rs
+++ b/src/command/abort.rs
@@ -3,6 +3,7 @@
 //! # Spec: §6.24
 
 use crate::error::Error;
+use crate::payload_util::require_exact_len;
 use alloc::vec::Vec;
 
 /// `osdp_ABORT` body (empty).
@@ -17,12 +18,7 @@ impl Abort {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if !data.is_empty() {
-            return Err(Error::MalformedPayload {
-                code: 0xA2,
-                reason: "ABORT has no payload",
-            });
-        }
+        require_exact_len(data, 0, 0xA2)?;
         Ok(Self)
     }
 }
@@ -41,7 +37,7 @@ mod tests {
     fn decode_rejects_payload() {
         assert!(matches!(
             Abort::decode(&[0xFF]),
-            Err(Error::MalformedPayload { code: 0xA2, .. })
+            Err(Error::PayloadLength { code: 0xA2, .. })
         ));
     }
 }

--- a/src/command/acu_rx_size.rs
+++ b/src/command/acu_rx_size.rs
@@ -33,3 +33,24 @@ impl AcuRxSize {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let body = AcuRxSize { max_size: 0x0123 };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0x23, 0x01]);
+        assert_eq!(AcuRxSize::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn decode_rejects_short() {
+        assert!(matches!(
+            AcuRxSize::decode(&[0x10]),
+            Err(Error::MalformedPayload { code: 0x7B, .. })
+        ));
+    }
+}

--- a/src/command/acu_rx_size.rs
+++ b/src/command/acu_rx_size.rs
@@ -5,6 +5,7 @@
 //! Body is a 16-bit little-endian byte count.
 
 use crate::error::Error;
+use crate::payload_util::require_exact_len;
 use alloc::vec::Vec;
 
 /// `osdp_ACURXSIZE` body.
@@ -22,12 +23,7 @@ impl AcuRxSize {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() != 2 {
-            return Err(Error::MalformedPayload {
-                code: 0x7B,
-                reason: "ACURXSIZE requires 2 bytes",
-            });
-        }
+        require_exact_len(data, 2, 0x7B)?;
         Ok(Self {
             max_size: u16::from_le_bytes([data[0], data[1]]),
         })
@@ -50,7 +46,7 @@ mod tests {
     fn decode_rejects_short() {
         assert!(matches!(
             AcuRxSize::decode(&[0x10]),
-            Err(Error::MalformedPayload { code: 0x7B, .. })
+            Err(Error::PayloadLength { code: 0x7B, .. })
         ));
     }
 }

--- a/src/command/biometric.rs
+++ b/src/command/biometric.rs
@@ -3,6 +3,7 @@
 //! # Spec: §6.14, §6.15, Tables 24–25
 
 use crate::error::Error;
+use crate::payload_util::{require_at_least, require_exact_len};
 use alloc::vec::Vec;
 
 /// Biometric type code (Table 24).
@@ -115,12 +116,7 @@ impl BioRead {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() != 4 {
-            return Err(Error::MalformedPayload {
-                code: 0x73,
-                reason: "BIOREAD requires 4 bytes",
-            });
-        }
+        require_exact_len(data, 4, 0x73)?;
         Ok(Self {
             reader: data[0],
             bio_type: BioType::from_byte(data[1]),
@@ -166,12 +162,7 @@ impl BioMatch {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() < 6 {
-            return Err(Error::MalformedPayload {
-                code: 0x74,
-                reason: "BIOMATCH requires at least 6 bytes",
-            });
-        }
+        require_at_least(data, 6, 0x74)?;
         let length = u16::from_le_bytes([data[4], data[5]]) as usize;
         if data.len() != 6 + length {
             return Err(Error::MalformedPayload {
@@ -210,7 +201,7 @@ mod tests {
     fn bioread_rejects_wrong_length() {
         assert!(matches!(
             BioRead::decode(&[0; 5]),
-            Err(Error::MalformedPayload { code: 0x73, .. })
+            Err(Error::PayloadLength { code: 0x73, .. })
         ));
     }
 

--- a/src/command/biometric.rs
+++ b/src/command/biometric.rs
@@ -188,3 +188,62 @@ impl BioMatch {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bioread_roundtrip() {
+        let body = BioRead {
+            reader: 0x02,
+            bio_type: BioType::LeftThumb,
+            bio_format: BioFormat::FingerprintAnsi378,
+            quality: 80,
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0x02, 0x06, 0x02, 80]);
+        assert_eq!(BioRead::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn bioread_rejects_wrong_length() {
+        assert!(matches!(
+            BioRead::decode(&[0; 5]),
+            Err(Error::MalformedPayload { code: 0x73, .. })
+        ));
+    }
+
+    #[test]
+    fn biotype_unknown_decodes_to_not_specified() {
+        assert_eq!(BioType::from_byte(0xFF), BioType::NotSpecified);
+    }
+
+    #[test]
+    fn biomatch_roundtrip() {
+        let body = BioMatch {
+            reader: 0x01,
+            bio_type: BioType::RightIndex,
+            bio_format: BioFormat::FingerprintRawPgm,
+            quality: 75,
+            template: alloc::vec![0xDE, 0xAD, 0xBE, 0xEF],
+        };
+        let bytes = body.encode().unwrap();
+        // 4 fixed bytes + 2 length bytes (LE 4 = [0x04, 0x00]) + 4 template bytes.
+        assert_eq!(
+            bytes,
+            [0x01, 0x02, 0x01, 75, 0x04, 0x00, 0xDE, 0xAD, 0xBE, 0xEF]
+        );
+        assert_eq!(BioMatch::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn biomatch_rejects_length_disagreement() {
+        // Header claims 5-byte template but payload only has 3 bytes after header.
+        let bad = [0x01, 0x02, 0x01, 75, 0x05, 0x00, 0xAA, 0xBB, 0xCC];
+        assert!(matches!(
+            BioMatch::decode(&bad),
+            Err(Error::MalformedPayload { code: 0x74, .. })
+        ));
+    }
+}

--- a/src/command/buzzer.rs
+++ b/src/command/buzzer.rs
@@ -78,3 +78,35 @@ impl BuzzerControl {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let body = BuzzerControl {
+            reader: 0x00,
+            tone: BuzzerTone::Default,
+            on_time: 5,
+            off_time: 5,
+            count: 3,
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0x00, 0x02, 5, 5, 3]);
+        assert_eq!(BuzzerControl::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn decode_rejects_wrong_length() {
+        assert!(matches!(
+            BuzzerControl::decode(&[0; 4]),
+            Err(Error::MalformedPayload { code: 0x6A, .. })
+        ));
+    }
+
+    #[test]
+    fn unknown_tone_decodes_to_default() {
+        assert_eq!(BuzzerTone::from_byte(0x99), BuzzerTone::Default);
+    }
+}

--- a/src/command/buzzer.rs
+++ b/src/command/buzzer.rs
@@ -5,6 +5,7 @@
 //! Body is a 5-byte record per buzzer.
 
 use crate::error::Error;
+use crate::payload_util::require_exact_len;
 use alloc::vec::Vec;
 
 /// Buzzer tone code (Table 19).
@@ -63,12 +64,7 @@ impl BuzzerControl {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() != 5 {
-            return Err(Error::MalformedPayload {
-                code: 0x6A,
-                reason: "BUZ requires 5 bytes",
-            });
-        }
+        require_exact_len(data, 5, 0x6A)?;
         Ok(Self {
             reader: data[0],
             tone: BuzzerTone::from_byte(data[1]),
@@ -101,7 +97,7 @@ mod tests {
     fn decode_rejects_wrong_length() {
         assert!(matches!(
             BuzzerControl::decode(&[0; 4]),
-            Err(Error::MalformedPayload { code: 0x6A, .. })
+            Err(Error::PayloadLength { code: 0x6A, .. })
         ));
     }
 

--- a/src/command/cap.rs
+++ b/src/command/cap.rs
@@ -34,3 +34,33 @@ impl Cap {
         Ok(Self { reserved: data[0] })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn standard_encodes_zero() {
+        assert_eq!(Cap::standard().encode().unwrap(), [0x00]);
+    }
+
+    #[test]
+    fn roundtrip_preserves_reserved() {
+        let body = Cap { reserved: 0x42 };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0x42]);
+        assert_eq!(Cap::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn decode_rejects_wrong_length() {
+        assert!(matches!(
+            Cap::decode(&[]),
+            Err(Error::MalformedPayload { code: 0x62, .. })
+        ));
+        assert!(matches!(
+            Cap::decode(&[0x00, 0x00]),
+            Err(Error::MalformedPayload { code: 0x62, .. })
+        ));
+    }
+}

--- a/src/command/cap.rs
+++ b/src/command/cap.rs
@@ -3,6 +3,7 @@
 //! # Spec: §6.3
 
 use crate::error::Error;
+use crate::payload_util::require_exact_len;
 use alloc::vec::Vec;
 
 /// `osdp_CAP` body.
@@ -25,12 +26,7 @@ impl Cap {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() != 1 {
-            return Err(Error::MalformedPayload {
-                code: 0x62,
-                reason: "CAP requires 1-byte reserved field",
-            });
-        }
+        require_exact_len(data, 1, 0x62)?;
         Ok(Self { reserved: data[0] })
     }
 }
@@ -56,11 +52,11 @@ mod tests {
     fn decode_rejects_wrong_length() {
         assert!(matches!(
             Cap::decode(&[]),
-            Err(Error::MalformedPayload { code: 0x62, .. })
+            Err(Error::PayloadLength { code: 0x62, .. })
         ));
         assert!(matches!(
             Cap::decode(&[0x00, 0x00]),
-            Err(Error::MalformedPayload { code: 0x62, .. })
+            Err(Error::PayloadLength { code: 0x62, .. })
         ));
     }
 }

--- a/src/command/chlng.rs
+++ b/src/command/chlng.rs
@@ -6,6 +6,7 @@
 //! The packet must carry an SCB of type `SCS_11`.
 
 use crate::error::Error;
+use crate::payload_util::require_exact_len;
 use alloc::vec::Vec;
 
 /// `osdp_CHLNG` body.
@@ -28,12 +29,7 @@ impl Chlng {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() != 8 {
-            return Err(Error::MalformedPayload {
-                code: 0x76,
-                reason: "CHLNG requires 8-byte RND.A",
-            });
-        }
+        require_exact_len(data, 8, 0x76)?;
         let mut rnd_a = [0u8; 8];
         rnd_a.copy_from_slice(data);
         Ok(Self { rnd_a })
@@ -56,11 +52,11 @@ mod tests {
     fn decode_rejects_wrong_length() {
         assert!(matches!(
             Chlng::decode(&[0; 7]),
-            Err(Error::MalformedPayload { code: 0x76, .. })
+            Err(Error::PayloadLength { code: 0x76, .. })
         ));
         assert!(matches!(
             Chlng::decode(&[0; 9]),
-            Err(Error::MalformedPayload { code: 0x76, .. })
+            Err(Error::PayloadLength { code: 0x76, .. })
         ));
     }
 }

--- a/src/command/chlng.rs
+++ b/src/command/chlng.rs
@@ -39,3 +39,28 @@ impl Chlng {
         Ok(Self { rnd_a })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let body = Chlng::new([0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88]);
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes.len(), 8);
+        assert_eq!(Chlng::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn decode_rejects_wrong_length() {
+        assert!(matches!(
+            Chlng::decode(&[0; 7]),
+            Err(Error::MalformedPayload { code: 0x76, .. })
+        ));
+        assert!(matches!(
+            Chlng::decode(&[0; 9]),
+            Err(Error::MalformedPayload { code: 0x76, .. })
+        ));
+    }
+}

--- a/src/command/comset.rs
+++ b/src/command/comset.rs
@@ -5,6 +5,7 @@
 //! Body is 5 bytes: `addr (1)` + `baud (4 LE)`.
 
 use crate::error::Error;
+use crate::payload_util::require_exact_len;
 use alloc::vec::Vec;
 
 /// `osdp_COMSET` body.
@@ -30,12 +31,7 @@ impl ComSet {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() != 5 {
-            return Err(Error::MalformedPayload {
-                code: 0x6E,
-                reason: "COMSET requires 5 bytes",
-            });
-        }
+        require_exact_len(data, 5, 0x6E)?;
         Ok(Self {
             address: data[0],
             baud: u32::from_le_bytes([data[1], data[2], data[3], data[4]]),

--- a/src/command/file_transfer.rs
+++ b/src/command/file_transfer.rs
@@ -3,6 +3,7 @@
 //! # Spec: §6.21
 
 use crate::error::Error;
+use crate::payload_util::require_at_least;
 use alloc::vec::Vec;
 
 /// `osdp_FILETRANSFER` body.
@@ -38,12 +39,7 @@ impl FileTransfer {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() < 11 {
-            return Err(Error::MalformedPayload {
-                code: 0x7C,
-                reason: "FILETRANSFER requires at least 11 bytes",
-            });
-        }
+        require_at_least(data, 11, 0x7C)?;
         let total_size = u32::from_le_bytes([data[1], data[2], data[3], data[4]]);
         let offset = u32::from_le_bytes([data[5], data[6], data[7], data[8]]);
         let frag_len = u16::from_le_bytes([data[9], data[10]]) as usize;
@@ -89,7 +85,7 @@ mod tests {
     fn decode_rejects_short_header() {
         assert!(matches!(
             FileTransfer::decode(&[0; 10]),
-            Err(Error::MalformedPayload { code: 0x7C, .. })
+            Err(Error::PayloadTooShort { code: 0x7C, .. })
         ));
     }
 

--- a/src/command/file_transfer.rs
+++ b/src/command/file_transfer.rs
@@ -61,3 +61,47 @@ impl FileTransfer {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let body = FileTransfer {
+            file_type: 0x07,
+            total_size: 0x0000_0100,
+            offset: 0x0000_0040,
+            fragment: alloc::vec![0xAA, 0xBB, 0xCC],
+        };
+        let bytes = body.encode().unwrap();
+        // file_type | total_size LE | offset LE | frag_len LE | fragment
+        assert_eq!(
+            bytes,
+            [
+                0x07, 0x00, 0x01, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x03, 0x00, 0xAA, 0xBB, 0xCC
+            ]
+        );
+        assert_eq!(FileTransfer::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn decode_rejects_short_header() {
+        assert!(matches!(
+            FileTransfer::decode(&[0; 10]),
+            Err(Error::MalformedPayload { code: 0x7C, .. })
+        ));
+    }
+
+    #[test]
+    fn decode_rejects_length_mismatch() {
+        // Header advertises a 5-byte fragment but only 2 bytes follow.
+        let bad = [
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05, 0x00, 0xAA, 0xBB,
+        ];
+        assert!(matches!(
+            FileTransfer::decode(&bad),
+            Err(Error::MalformedPayload { code: 0x7C, .. })
+        ));
+    }
+}

--- a/src/command/id.rs
+++ b/src/command/id.rs
@@ -5,6 +5,7 @@
 //! Body is a single `Reserved` byte (always `0x00`).
 
 use crate::error::Error;
+use crate::payload_util::require_exact_len;
 use alloc::vec::Vec;
 
 /// `osdp_ID` body.
@@ -27,12 +28,7 @@ impl Id {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() != 1 {
-            return Err(Error::MalformedPayload {
-                code: 0x61,
-                reason: "ID requires 1-byte reserved field",
-            });
-        }
+        require_exact_len(data, 1, 0x61)?;
         Ok(Self { reserved: data[0] })
     }
 }
@@ -58,7 +54,7 @@ mod tests {
     fn decode_rejects_wrong_length() {
         assert!(matches!(
             Id::decode(&[]),
-            Err(Error::MalformedPayload { code: 0x61, .. })
+            Err(Error::PayloadLength { code: 0x61, .. })
         ));
     }
 }

--- a/src/command/id.rs
+++ b/src/command/id.rs
@@ -36,3 +36,29 @@ impl Id {
         Ok(Self { reserved: data[0] })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn standard_encodes_zero() {
+        assert_eq!(Id::standard().encode().unwrap(), [0x00]);
+    }
+
+    #[test]
+    fn roundtrip_preserves_reserved() {
+        let body = Id { reserved: 0x55 };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0x55]);
+        assert_eq!(Id::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn decode_rejects_wrong_length() {
+        assert!(matches!(
+            Id::decode(&[]),
+            Err(Error::MalformedPayload { code: 0x61, .. })
+        ));
+    }
+}

--- a/src/command/keep_active.rs
+++ b/src/command/keep_active.rs
@@ -33,3 +33,26 @@ impl KeepActive {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let body = KeepActive {
+            duration_ms: 0x1234,
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0x34, 0x12]);
+        assert_eq!(KeepActive::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn decode_rejects_wrong_length() {
+        assert!(matches!(
+            KeepActive::decode(&[0x10]),
+            Err(Error::MalformedPayload { code: 0xA7, .. })
+        ));
+    }
+}

--- a/src/command/keep_active.rs
+++ b/src/command/keep_active.rs
@@ -5,6 +5,7 @@
 //! Body is a 16-bit little-endian millisecond duration.
 
 use crate::error::Error;
+use crate::payload_util::require_exact_len;
 use alloc::vec::Vec;
 
 /// `osdp_KEEPACTIVE` body.
@@ -22,12 +23,7 @@ impl KeepActive {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() != 2 {
-            return Err(Error::MalformedPayload {
-                code: 0xA7,
-                reason: "KEEPACTIVE requires 2 bytes",
-            });
-        }
+        require_exact_len(data, 2, 0xA7)?;
         Ok(Self {
             duration_ms: u16::from_le_bytes([data[0], data[1]]),
         })
@@ -52,7 +48,7 @@ mod tests {
     fn decode_rejects_wrong_length() {
         assert!(matches!(
             KeepActive::decode(&[0x10]),
-            Err(Error::MalformedPayload { code: 0xA7, .. })
+            Err(Error::PayloadLength { code: 0xA7, .. })
         ));
     }
 }

--- a/src/command/keyset.rs
+++ b/src/command/keyset.rs
@@ -70,3 +70,36 @@ impl KeySet {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scbk_roundtrip() {
+        let key = [0xAAu8; 16];
+        let body = KeySet::scbk(key);
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes[0], 0x01);
+        assert_eq!(bytes[1], 16);
+        assert_eq!(&bytes[2..], &key);
+        assert_eq!(KeySet::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn decode_rejects_short() {
+        assert!(matches!(
+            KeySet::decode(&[0x01]),
+            Err(Error::MalformedPayload { code: 0x75, .. })
+        ));
+    }
+
+    #[test]
+    fn decode_rejects_length_mismatch() {
+        // key_len says 4 but only 2 key bytes follow.
+        assert!(matches!(
+            KeySet::decode(&[0x01, 0x04, 0xDE, 0xAD]),
+            Err(Error::MalformedPayload { code: 0x75, .. })
+        ));
+    }
+}

--- a/src/command/keyset.rs
+++ b/src/command/keyset.rs
@@ -14,6 +14,7 @@
 //! of the key (16 for AES-128).
 
 use crate::error::Error;
+use crate::payload_util::require_at_least;
 use alloc::vec::Vec;
 
 /// `osdp_KEYSET` body.
@@ -51,12 +52,7 @@ impl KeySet {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() < 2 {
-            return Err(Error::MalformedPayload {
-                code: 0x75,
-                reason: "KEYSET requires at least 2 bytes",
-            });
-        }
+        require_at_least(data, 2, 0x75)?;
         let key_len = data[1] as usize;
         if data.len() != 2 + key_len {
             return Err(Error::MalformedPayload {
@@ -90,7 +86,7 @@ mod tests {
     fn decode_rejects_short() {
         assert!(matches!(
             KeySet::decode(&[0x01]),
-            Err(Error::MalformedPayload { code: 0x75, .. })
+            Err(Error::PayloadTooShort { code: 0x75, .. })
         ));
     }
 

--- a/src/command/led.rs
+++ b/src/command/led.rs
@@ -6,6 +6,7 @@
 //! "temporary" control, then a 6-byte "permanent" control).
 
 use crate::error::Error;
+use crate::payload_util::require_positive_multiple_of;
 use alloc::vec::Vec;
 
 /// LED color values — Table 18.
@@ -165,12 +166,7 @@ impl LedControl {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.is_empty() || data.len() % LedRecord::WIRE_LEN != 0 {
-            return Err(Error::MalformedPayload {
-                code: 0x69,
-                reason: "LED payload must be a multiple of 14 bytes",
-            });
-        }
+        require_positive_multiple_of(data, LedRecord::WIRE_LEN, 0x69)?;
         let records = data
             .chunks_exact(LedRecord::WIRE_LEN)
             .map(LedRecord::decode)

--- a/src/command/local_status.rs
+++ b/src/command/local_status.rs
@@ -40,3 +40,46 @@ empty_status!(LocalStatus, 0x64, "osdp_LSTAT");
 empty_status!(InputStatus, 0x65, "osdp_ISTAT");
 empty_status!(OutputStatus, 0x66, "osdp_OSTAT");
 empty_status!(ReaderStatus, 0x67, "osdp_RSTAT");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lstat_roundtrip_empty() {
+        assert!(LocalStatus.encode().unwrap().is_empty());
+        assert_eq!(LocalStatus::decode(&[]).unwrap(), LocalStatus);
+    }
+
+    #[test]
+    fn lstat_rejects_payload() {
+        assert!(matches!(
+            LocalStatus::decode(&[0x00]),
+            Err(Error::MalformedPayload { code: 0x64, .. })
+        ));
+    }
+
+    #[test]
+    fn istat_rejects_payload() {
+        assert!(matches!(
+            InputStatus::decode(&[0x00]),
+            Err(Error::MalformedPayload { code: 0x65, .. })
+        ));
+    }
+
+    #[test]
+    fn ostat_rejects_payload() {
+        assert!(matches!(
+            OutputStatus::decode(&[0x00]),
+            Err(Error::MalformedPayload { code: 0x66, .. })
+        ));
+    }
+
+    #[test]
+    fn rstat_rejects_payload() {
+        assert!(matches!(
+            ReaderStatus::decode(&[0x00]),
+            Err(Error::MalformedPayload { code: 0x67, .. })
+        ));
+    }
+}

--- a/src/command/local_status.rs
+++ b/src/command/local_status.rs
@@ -8,6 +8,7 @@
 //! # Spec: §6.4 – §6.7
 
 use crate::error::Error;
+use crate::payload_util::require_exact_len;
 use alloc::vec::Vec;
 
 macro_rules! empty_status {
@@ -24,12 +25,7 @@ macro_rules! empty_status {
 
             /// Decode (must be empty).
             pub fn decode(data: &[u8]) -> Result<Self, Error> {
-                if !data.is_empty() {
-                    return Err(Error::MalformedPayload {
-                        code: $code,
-                        reason: concat!($name, " has no payload"),
-                    });
-                }
+                require_exact_len(data, 0, $code)?;
                 Ok(Self)
             }
         }
@@ -55,7 +51,7 @@ mod tests {
     fn lstat_rejects_payload() {
         assert!(matches!(
             LocalStatus::decode(&[0x00]),
-            Err(Error::MalformedPayload { code: 0x64, .. })
+            Err(Error::PayloadLength { code: 0x64, .. })
         ));
     }
 
@@ -63,7 +59,7 @@ mod tests {
     fn istat_rejects_payload() {
         assert!(matches!(
             InputStatus::decode(&[0x00]),
-            Err(Error::MalformedPayload { code: 0x65, .. })
+            Err(Error::PayloadLength { code: 0x65, .. })
         ));
     }
 
@@ -71,7 +67,7 @@ mod tests {
     fn ostat_rejects_payload() {
         assert!(matches!(
             OutputStatus::decode(&[0x00]),
-            Err(Error::MalformedPayload { code: 0x66, .. })
+            Err(Error::PayloadLength { code: 0x66, .. })
         ));
     }
 
@@ -79,7 +75,7 @@ mod tests {
     fn rstat_rejects_payload() {
         assert!(matches!(
             ReaderStatus::decode(&[0x00]),
-            Err(Error::MalformedPayload { code: 0x67, .. })
+            Err(Error::PayloadLength { code: 0x67, .. })
         ));
     }
 }

--- a/src/command/mfg.rs
+++ b/src/command/mfg.rs
@@ -5,6 +5,7 @@
 //! Body is `OUI (3 bytes)` + opaque vendor data.
 
 use crate::error::Error;
+use crate::payload_util::require_at_least;
 use alloc::vec::Vec;
 
 /// `osdp_MFG` body.
@@ -27,12 +28,7 @@ impl Mfg {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() < 3 {
-            return Err(Error::MalformedPayload {
-                code: 0x80,
-                reason: "MFG requires 3-byte OUI",
-            });
-        }
+        require_at_least(data, 3, 0x80)?;
         let mut oui = [0u8; 3];
         oui.copy_from_slice(&data[..3]);
         Ok(Self {
@@ -72,7 +68,7 @@ mod tests {
     fn decode_rejects_short_oui() {
         assert!(matches!(
             Mfg::decode(&[0x00, 0x06]),
-            Err(Error::MalformedPayload { code: 0x80, .. })
+            Err(Error::PayloadTooShort { code: 0x80, .. })
         ));
     }
 }

--- a/src/command/mfg.rs
+++ b/src/command/mfg.rs
@@ -41,3 +41,38 @@ impl Mfg {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let body = Mfg {
+            oui: [0x00, 0x06, 0x8E],
+            payload: alloc::vec![0xCA, 0xFE],
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0x00, 0x06, 0x8E, 0xCA, 0xFE]);
+        assert_eq!(Mfg::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn empty_payload_is_valid() {
+        let body = Mfg {
+            oui: [0xAA, 0xBB, 0xCC],
+            payload: alloc::vec::Vec::new(),
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0xAA, 0xBB, 0xCC]);
+        assert_eq!(Mfg::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn decode_rejects_short_oui() {
+        assert!(matches!(
+            Mfg::decode(&[0x00, 0x06]),
+            Err(Error::MalformedPayload { code: 0x80, .. })
+        ));
+    }
+}

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -11,6 +11,7 @@
 //! ```
 
 use crate::error::Error;
+use crate::payload_util::require_positive_multiple_of;
 use alloc::vec::Vec;
 
 /// Output control codes — Table 14.
@@ -101,12 +102,7 @@ impl OutputControl {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.is_empty() || data.len() % OutputRecord::WIRE_LEN != 0 {
-            return Err(Error::MalformedPayload {
-                code: 0x68,
-                reason: "OUT payload must be a multiple of 4 bytes",
-            });
-        }
+        require_positive_multiple_of(data, OutputRecord::WIRE_LEN, 0x68)?;
         let mut records = Vec::with_capacity(data.len() / OutputRecord::WIRE_LEN);
         for chunk in data.chunks_exact(OutputRecord::WIRE_LEN) {
             records.push(OutputRecord {
@@ -147,7 +143,7 @@ mod tests {
     fn decode_rejects_misaligned_payload() {
         assert!(matches!(
             OutputControl::decode(&[0x00, 0x00, 0x00]),
-            Err(Error::MalformedPayload { code: 0x68, .. })
+            Err(Error::PayloadNotMultiple { code: 0x68, .. })
         ));
     }
 

--- a/src/command/output.rs
+++ b/src/command/output.rs
@@ -118,3 +118,44 @@ impl OutputControl {
         Ok(Self { records })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_record_roundtrip() {
+        let body = OutputControl::new(alloc::vec![OutputRecord {
+            output: 0x02,
+            code: OutputControlCode::PermanentOnAllowTimed,
+            timer: 0x00FA,
+        }]);
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0x02, 0x04, 0xFA, 0x00]);
+        assert_eq!(OutputControl::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn empty_records_rejected() {
+        assert!(matches!(
+            OutputControl::new(Vec::new()).encode(),
+            Err(Error::MalformedPayload { code: 0x68, .. })
+        ));
+    }
+
+    #[test]
+    fn decode_rejects_misaligned_payload() {
+        assert!(matches!(
+            OutputControl::decode(&[0x00, 0x00, 0x00]),
+            Err(Error::MalformedPayload { code: 0x68, .. })
+        ));
+    }
+
+    #[test]
+    fn decode_rejects_unknown_control_code() {
+        assert!(matches!(
+            OutputControl::decode(&[0x00, 0x99, 0x00, 0x00]),
+            Err(Error::MalformedPayload { code: 0x68, .. })
+        ));
+    }
+}

--- a/src/command/piv.rs
+++ b/src/command/piv.rs
@@ -112,3 +112,69 @@ impl CrAuth {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pivdata_roundtrip() {
+        let body = PivData {
+            object_id: [0x5F, 0xC1, 0x02],
+            element_id: 0x01,
+            offset: 0x0010,
+            data: alloc::vec![0xAA, 0xBB],
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0x5F, 0xC1, 0x02, 0x01, 0x10, 0x00, 0xAA, 0xBB]);
+        assert_eq!(PivData::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn pivdata_rejects_short_header() {
+        assert!(matches!(
+            PivData::decode(&[0; 5]),
+            Err(Error::MalformedPayload { code: 0xA3, .. })
+        ));
+    }
+
+    #[test]
+    fn genauth_roundtrip() {
+        let body = GenAuth {
+            algorithm: 0x07,
+            key_ref: 0x9A,
+            auth_template: alloc::vec![0x7C, 0x02, 0x80, 0x00],
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0x07, 0x9A, 0x7C, 0x02, 0x80, 0x00]);
+        assert_eq!(GenAuth::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn genauth_rejects_short() {
+        assert!(matches!(
+            GenAuth::decode(&[0x07]),
+            Err(Error::MalformedPayload { code: 0xA4, .. })
+        ));
+    }
+
+    #[test]
+    fn crauth_passthrough() {
+        let body = CrAuth {
+            challenge: alloc::vec![0x11; 16],
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes.len(), 16);
+        assert_eq!(CrAuth::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn crauth_accepts_empty() {
+        assert_eq!(
+            CrAuth::decode(&[]).unwrap(),
+            CrAuth {
+                challenge: Vec::new()
+            }
+        );
+    }
+}

--- a/src/command/piv.rs
+++ b/src/command/piv.rs
@@ -7,6 +7,7 @@
 //! when their payload exceeds a single packet's RX size.
 
 use crate::error::Error;
+use crate::payload_util::require_at_least;
 use alloc::vec::Vec;
 
 /// `osdp_PIVDATA` body.
@@ -38,12 +39,7 @@ impl PivData {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() < 6 {
-            return Err(Error::MalformedPayload {
-                code: 0xA3,
-                reason: "PIVDATA requires at least 6 bytes",
-            });
-        }
+        require_at_least(data, 6, 0xA3)?;
         let mut object_id = [0u8; 3];
         object_id.copy_from_slice(&data[..3]);
         Ok(Self {
@@ -78,12 +74,7 @@ impl GenAuth {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() < 2 {
-            return Err(Error::MalformedPayload {
-                code: 0xA4,
-                reason: "GENAUTH requires at least 2 bytes",
-            });
-        }
+        require_at_least(data, 2, 0xA4)?;
         Ok(Self {
             algorithm: data[0],
             key_ref: data[1],
@@ -134,7 +125,7 @@ mod tests {
     fn pivdata_rejects_short_header() {
         assert!(matches!(
             PivData::decode(&[0; 5]),
-            Err(Error::MalformedPayload { code: 0xA3, .. })
+            Err(Error::PayloadTooShort { code: 0xA3, .. })
         ));
     }
 
@@ -154,7 +145,7 @@ mod tests {
     fn genauth_rejects_short() {
         assert!(matches!(
             GenAuth::decode(&[0x07]),
-            Err(Error::MalformedPayload { code: 0xA4, .. })
+            Err(Error::PayloadTooShort { code: 0xA4, .. })
         ));
     }
 

--- a/src/command/poll.rs
+++ b/src/command/poll.rs
@@ -26,3 +26,26 @@ impl Poll {
         Ok(Self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_is_empty() {
+        assert!(Poll.encode().unwrap().is_empty());
+    }
+
+    #[test]
+    fn decode_empty() {
+        assert_eq!(Poll::decode(&[]).unwrap(), Poll);
+    }
+
+    #[test]
+    fn decode_rejects_payload() {
+        assert!(matches!(
+            Poll::decode(&[0x00]),
+            Err(Error::MalformedPayload { code: 0x60, .. })
+        ));
+    }
+}

--- a/src/command/poll.rs
+++ b/src/command/poll.rs
@@ -3,6 +3,7 @@
 //! # Spec: §6.1
 
 use crate::error::Error;
+use crate::payload_util::require_exact_len;
 use alloc::vec::Vec;
 
 /// Empty body of the POLL command.
@@ -17,12 +18,7 @@ impl Poll {
 
     /// Decode (must be empty).
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if !data.is_empty() {
-            return Err(Error::MalformedPayload {
-                code: 0x60,
-                reason: "POLL has no payload",
-            });
-        }
+        require_exact_len(data, 0, 0x60)?;
         Ok(Self)
     }
 }
@@ -45,7 +41,7 @@ mod tests {
     fn decode_rejects_payload() {
         assert!(matches!(
             Poll::decode(&[0x00]),
-            Err(Error::MalformedPayload { code: 0x60, .. })
+            Err(Error::PayloadLength { code: 0x60, .. })
         ));
     }
 }

--- a/src/command/scrypt.rs
+++ b/src/command/scrypt.rs
@@ -42,3 +42,24 @@ impl SCrypt {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let body = SCrypt::new([0x42u8; 16]);
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes.len(), 16);
+        assert_eq!(SCrypt::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn decode_rejects_wrong_length() {
+        assert!(matches!(
+            SCrypt::decode(&[0; 15]),
+            Err(Error::MalformedPayload { code: 0x77, .. })
+        ));
+    }
+}

--- a/src/command/scrypt.rs
+++ b/src/command/scrypt.rs
@@ -5,6 +5,7 @@
 //! Body is the 16-byte server cryptogram. Packet carries SCB of type `SCS_13`.
 
 use crate::error::Error;
+use crate::payload_util::require_exact_len;
 use alloc::vec::Vec;
 
 /// `osdp_SCRYPT` body.
@@ -29,12 +30,7 @@ impl SCrypt {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() != 16 {
-            return Err(Error::MalformedPayload {
-                code: 0x77,
-                reason: "SCRYPT requires 16-byte cryptogram",
-            });
-        }
+        require_exact_len(data, 16, 0x77)?;
         let mut c = [0u8; 16];
         c.copy_from_slice(data);
         Ok(Self {
@@ -59,7 +55,7 @@ mod tests {
     fn decode_rejects_wrong_length() {
         assert!(matches!(
             SCrypt::decode(&[0; 15]),
-            Err(Error::MalformedPayload { code: 0x77, .. })
+            Err(Error::PayloadLength { code: 0x77, .. })
         ));
     }
 }

--- a/src/command/text.rs
+++ b/src/command/text.rs
@@ -11,6 +11,7 @@
 //! ```
 
 use crate::error::Error;
+use crate::payload_util::require_at_least;
 use alloc::vec::Vec;
 
 /// Text command codes (Table 21).
@@ -100,12 +101,7 @@ impl Text {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() < 6 {
-            return Err(Error::MalformedPayload {
-                code: 0x6B,
-                reason: "TEXT requires at least 6 bytes",
-            });
-        }
+        require_at_least(data, 6, 0x6B)?;
         let length = data[5] as usize;
         if data.len() != 6 + length {
             return Err(Error::MalformedPayload {

--- a/src/command/text.rs
+++ b/src/command/text.rs
@@ -125,3 +125,56 @@ impl Text {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let body = Text {
+            reader: 0x00,
+            command: TextCommand::PermanentNoWrap,
+            temp_time_s: 0,
+            row: 1,
+            column: 1,
+            text: alloc::vec![b'O', b'K'],
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0x00, 0x01, 0x00, 0x01, 0x01, 0x02, b'O', b'K']);
+        assert_eq!(Text::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn rejects_non_ascii_text_on_encode() {
+        let body = Text {
+            reader: 0,
+            command: TextCommand::PermanentNoWrap,
+            temp_time_s: 0,
+            row: 1,
+            column: 1,
+            text: alloc::vec![0x1F], // below printable
+        };
+        assert!(matches!(
+            body.encode(),
+            Err(Error::MalformedPayload { code: 0x6B, .. })
+        ));
+    }
+
+    #[test]
+    fn decode_rejects_unknown_command_code() {
+        assert!(matches!(
+            Text::decode(&[0x00, 0x99, 0x00, 0x01, 0x01, 0x00]),
+            Err(Error::MalformedPayload { code: 0x6B, .. })
+        ));
+    }
+
+    #[test]
+    fn decode_rejects_length_mismatch() {
+        // Header claims 5-byte text but only 1 byte follows.
+        assert!(matches!(
+            Text::decode(&[0x00, 0x01, 0x00, 0x01, 0x01, 0x05, b'A']),
+            Err(Error::MalformedPayload { code: 0x6B, .. })
+        ));
+    }
+}

--- a/src/command/xwrite.rs
+++ b/src/command/xwrite.rs
@@ -8,6 +8,7 @@
 //! - `0x01` (transparent smart card): APDU transmission, secure PIN entry.
 
 use crate::error::Error;
+use crate::payload_util::require_at_least;
 use alloc::vec::Vec;
 
 /// Mode-00 sub-commands.
@@ -52,12 +53,7 @@ impl XWrite {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.is_empty() {
-            return Err(Error::MalformedPayload {
-                code: 0xA1,
-                reason: "XWR requires XRW_MODE byte",
-            });
-        }
+        require_at_least(data, 1, 0xA1)?;
         Ok(Self {
             mode: data[0],
             payload: data[1..].to_vec(),
@@ -95,7 +91,7 @@ mod tests {
     fn empty_decode_rejected() {
         assert!(matches!(
             XWrite::decode(&[]),
-            Err(Error::MalformedPayload { code: 0xA1, .. })
+            Err(Error::PayloadTooShort { code: 0xA1, .. })
         ));
     }
 }

--- a/src/command/xwrite.rs
+++ b/src/command/xwrite.rs
@@ -64,3 +64,38 @@ impl XWrite {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let body = XWrite {
+            mode: 0x01,
+            payload: alloc::vec![0x02, 0xDE, 0xAD],
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0x01, 0x02, 0xDE, 0xAD]);
+        assert_eq!(XWrite::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn mode_only_is_valid() {
+        let body = XWrite {
+            mode: 0x00,
+            payload: Vec::new(),
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0x00]);
+        assert_eq!(XWrite::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn empty_decode_rejected() {
+        assert!(matches!(
+            XWrite::decode(&[]),
+            Err(Error::MalformedPayload { code: 0xA1, .. })
+        ));
+    }
+}

--- a/src/driver/acu.rs
+++ b/src/driver/acu.rs
@@ -229,6 +229,21 @@ impl<T: Transport, C: Clock> Acu<T, C> {
     ///   prior reply, per §5.7 / Table 2.
     /// - When the PD has been silent for ≥ [`crate::OFFLINE_THRESHOLD_MS`],
     ///   returns [`ExchangeOutcome::Offline`].
+    ///
+    #[cfg_attr(feature = "_docs", aquamarine::aquamarine)]
+    /// ```mermaid
+    /// flowchart TD
+    ///     enter([exchange]) --> off{is_offline?}
+    ///     off -- yes --> O[Offline]
+    ///     off -- no --> send[send_with_sqn]
+    ///     send --> recv[recv_one_with_sqn]
+    ///     recv --> kind{reply?}
+    ///     kind -- BUSY --> bu["Busy<br/>(SQN unchanged)"]
+    ///     kind -- typed --> ok["Reply<br/>(bump_sqn)"]
+    ///     kind -- Timeout --> retry{"retries left?<br/>budget left?<br/>not offline?"}
+    ///     retry -- yes --> send
+    ///     retry -- no --> T[Timeout]
+    /// ```
     pub fn exchange(
         &mut self,
         pd_addr: u8,

--- a/src/driver/acu.rs
+++ b/src/driver/acu.rs
@@ -180,7 +180,7 @@ impl<T: Transport, C: Clock> Acu<T, C> {
     /// check the deadline and either return `Timeout` or immediately
     /// return — the caller is expected to call us again later.
     pub fn receive(&mut self, pd: &mut PdState) -> Result<Reply, Error> {
-        let (reply_code, data) = self.recv_loop()?;
+        let (reply_code, _sqn, data) = self.recv_loop()?;
         let now = self.clock.now_ms();
         pd.mark_seen(now);
         pd.bump_sqn();
@@ -191,7 +191,10 @@ impl<T: Transport, C: Clock> Acu<T, C> {
     /// [`Self::recv_one_with_sqn`]. Drains the transport into `rx_buf` until a
     /// complete packet can be parsed, the per-attempt reply-delay budget is
     /// exhausted, or the transport has signalled "no data" too many times.
-    fn recv_loop(&mut self) -> Result<(ReplyCode, Vec<u8>), Error> {
+    ///
+    /// Returns the parsed reply code, the SQN it carried, and the raw DATA
+    /// bytes. SQN policy is left to the caller.
+    fn recv_loop(&mut self) -> Result<(ReplyCode, Sqn, Vec<u8>), Error> {
         let start = self.clock.now_ms();
         let mut empty_reads = 0u8;
         loop {
@@ -278,20 +281,31 @@ impl<T: Transport, C: Clock> Acu<T, C> {
 
     /// Same as [`Self::receive`] but without mutating any [`PdState`] (used
     /// inside [`Self::exchange`] which has its own bookkeeping).
-    fn recv_one_with_sqn(&mut self, _expected_sqn: Sqn) -> Result<Reply, Error> {
-        let (reply_code, data) = self.recv_loop()?;
+    ///
+    /// Enforces §5.7 / Table 2: the PD must echo the SQN we sent. `osdp_BUSY`
+    /// is the documented exception — it is always SQN=0 regardless of what
+    /// the ACU sent — so its SQN is not checked.
+    fn recv_one_with_sqn(&mut self, expected_sqn: Sqn) -> Result<Reply, Error> {
+        let (reply_code, parsed_sqn, data) = self.recv_loop()?;
+        if reply_code != ReplyCode::Busy && parsed_sqn != expected_sqn {
+            return Err(Error::SqnMismatch {
+                expected: expected_sqn.value(),
+                got: parsed_sqn.value(),
+            });
+        }
         Reply::decode(reply_code, &data)
     }
 
-    fn try_parse_packet(&mut self) -> Result<Option<(ReplyCode, Vec<u8>)>, Error> {
+    fn try_parse_packet(&mut self) -> Result<Option<(ReplyCode, Sqn, Vec<u8>)>, Error> {
         while let Some(som_pos) = self.rx_buf.iter().position(|&b| b == crate::SOM) {
             self.rx_buf.drain(..som_pos);
             match ParsedPacket::parse(&self.rx_buf) {
                 Ok((parsed, used)) => {
                     let code = ReplyCode::from_byte(parsed.code)?;
+                    let sqn = parsed.ctrl.sqn;
                     let data = parsed.data.to_vec();
                     self.rx_buf.drain(..used);
-                    return Ok(Some((code, data)));
+                    return Ok(Some((code, sqn, data)));
                 }
                 Err(Error::Truncated { .. }) => return Ok(None),
                 Err(Error::BadSom(_)) => {
@@ -362,5 +376,75 @@ mod tests {
         clock.set(crate::REPLY_DELAY_MS as u64 + 1);
         let outcome = acu.exchange(0x05, &mut pd, &Command::Poll(Poll)).unwrap();
         assert_eq!(outcome, ExchangeOutcome::Timeout);
+    }
+
+    #[test]
+    fn exchange_rejects_reply_with_wrong_sqn() {
+        // The ACU sends with SQN=1; we feed it back an ACK that claims SQN=2.
+        // Per §5.7 / Table 2 this is a stale/desync'd PD and must be rejected.
+        let clock = MockClock::new();
+        let mut transport = VecTransport::new();
+        let stale = PacketBuilder::plain(
+            Address::reply(0x05).unwrap(),
+            ControlByte::new(Sqn::new(2).unwrap(), CtrlFlags::USE_CRC),
+            crate::reply::ReplyCode::Ack.as_byte(),
+            alloc::vec::Vec::new(),
+        )
+        .encode()
+        .unwrap();
+        transport.feed(&stale);
+
+        let mut acu = Acu::new(transport, clock);
+        acu.retry = RetryConfig {
+            max_retries: 0,
+            overall_budget_ms: 0,
+        };
+        let mut pd = PdState {
+            next_sqn: Sqn::new(1).unwrap(),
+            ..Default::default()
+        };
+        pd.mark_seen(0);
+
+        let err = acu
+            .exchange(0x05, &mut pd, &Command::Poll(Poll))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            Error::SqnMismatch {
+                expected: 1,
+                got: 2
+            }
+        ));
+    }
+
+    #[test]
+    fn exchange_accepts_busy_with_sqn_zero() {
+        // BUSY always carries SQN=0 regardless of what the ACU sent
+        // (Annex A.2). Verify we accept it instead of flagging SQN mismatch.
+        let clock = MockClock::new();
+        let mut transport = VecTransport::new();
+        let busy = PacketBuilder::plain(
+            Address::reply(0x05).unwrap(),
+            ControlByte::new(Sqn::ZERO, CtrlFlags::USE_CRC),
+            crate::reply::ReplyCode::Busy.as_byte(),
+            alloc::vec::Vec::new(),
+        )
+        .encode()
+        .unwrap();
+        transport.feed(&busy);
+
+        let mut acu = Acu::new(transport, clock);
+        acu.retry = RetryConfig {
+            max_retries: 0,
+            overall_budget_ms: 0,
+        };
+        let mut pd = PdState {
+            next_sqn: Sqn::new(2).unwrap(),
+            ..Default::default()
+        };
+        pd.mark_seen(0);
+
+        let outcome = acu.exchange(0x05, &mut pd, &Command::Poll(Poll)).unwrap();
+        assert_eq!(outcome, ExchangeOutcome::Busy);
     }
 }

--- a/src/driver/acu.rs
+++ b/src/driver/acu.rs
@@ -12,6 +12,17 @@ use crate::reply::{Reply, ReplyCode};
 use crate::transport::Transport;
 use alloc::vec::Vec;
 
+/// Bytes pulled from the transport per `Transport::read` call. Sized so a
+/// minimal frame fits in a single read but small enough that the stack
+/// footprint stays modest.
+const RX_CHUNK_LEN: usize = 64;
+
+/// Number of consecutive `Transport::read(..) -> Ok(0)` returns we tolerate
+/// inside a per-attempt budget before yielding control back to the caller as
+/// `Error::Timeout`. This stops us from spinning on a non-blocking transport
+/// that has nothing to deliver.
+const MAX_EMPTY_READS: u8 = 4;
+
 /// Per-PD bookkeeping owned by the ACU driver.
 #[derive(Debug, Clone)]
 pub struct PdState {
@@ -169,16 +180,25 @@ impl<T: Transport, C: Clock> Acu<T, C> {
     /// check the deadline and either return `Timeout` or immediately
     /// return — the caller is expected to call us again later.
     pub fn receive(&mut self, pd: &mut PdState) -> Result<Reply, Error> {
+        let (reply_code, data) = self.recv_loop()?;
+        let now = self.clock.now_ms();
+        pd.mark_seen(now);
+        pd.bump_sqn();
+        Reply::decode(reply_code, &data)
+    }
+
+    /// Inner read/parse loop shared by [`Self::receive`] and
+    /// [`Self::recv_one_with_sqn`]. Drains the transport into `rx_buf` until a
+    /// complete packet can be parsed, the per-attempt reply-delay budget is
+    /// exhausted, or the transport has signalled "no data" too many times.
+    fn recv_loop(&mut self) -> Result<(ReplyCode, Vec<u8>), Error> {
         let start = self.clock.now_ms();
         let mut empty_reads = 0u8;
         loop {
-            if let Some((reply_code, data)) = self.try_parse_packet()? {
-                let now = self.clock.now_ms();
-                pd.mark_seen(now);
-                pd.bump_sqn();
-                return Reply::decode(reply_code, &data);
+            if let Some(packet) = self.try_parse_packet()? {
+                return Ok(packet);
             }
-            let mut tmp = [0u8; 64];
+            let mut tmp = [0u8; RX_CHUNK_LEN];
             let n = self.transport.read(&mut tmp)?;
             if n > 0 {
                 self.rx_buf.extend_from_slice(&tmp[..n]);
@@ -189,10 +209,7 @@ impl<T: Transport, C: Clock> Acu<T, C> {
                 return Err(Error::Timeout);
             }
             empty_reads = empty_reads.saturating_add(1);
-            // Nonblocking transports signal "no data" via Ok(0); after a few
-            // such returns within budget we hand control back to the caller
-            // (still as Timeout) rather than spin.
-            if empty_reads >= 4 {
+            if empty_reads >= MAX_EMPTY_READS {
                 return Err(Error::Timeout);
             }
         }
@@ -262,27 +279,8 @@ impl<T: Transport, C: Clock> Acu<T, C> {
     /// Same as [`Self::receive`] but without mutating any [`PdState`] (used
     /// inside [`Self::exchange`] which has its own bookkeeping).
     fn recv_one_with_sqn(&mut self, _expected_sqn: Sqn) -> Result<Reply, Error> {
-        let start = self.clock.now_ms();
-        let mut empty_reads = 0u8;
-        loop {
-            if let Some((reply_code, data)) = self.try_parse_packet()? {
-                return Reply::decode(reply_code, &data);
-            }
-            let mut tmp = [0u8; 64];
-            let n = self.transport.read(&mut tmp)?;
-            if n > 0 {
-                self.rx_buf.extend_from_slice(&tmp[..n]);
-                empty_reads = 0;
-                continue;
-            }
-            if self.clock.now_ms().saturating_sub(start) >= self.reply_delay_ms as u64 {
-                return Err(Error::Timeout);
-            }
-            empty_reads = empty_reads.saturating_add(1);
-            if empty_reads >= 4 {
-                return Err(Error::Timeout);
-            }
-        }
+        let (reply_code, data) = self.recv_loop()?;
+        Reply::decode(reply_code, &data)
     }
 
     fn try_parse_packet(&mut self) -> Result<Option<(ReplyCode, Vec<u8>)>, Error> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -65,6 +65,33 @@ pub enum Error {
         /// One-line explanation.
         reason: &'static str,
     },
+    /// Payload length differs from the fixed length the message defines.
+    PayloadLength {
+        /// Command or reply code.
+        code: u8,
+        /// Bytes the spec mandates.
+        expected: usize,
+        /// Bytes actually delivered.
+        got: usize,
+    },
+    /// Payload is shorter than the minimum needed to parse the header.
+    PayloadTooShort {
+        /// Command or reply code.
+        code: u8,
+        /// Minimum bytes required.
+        min: usize,
+        /// Bytes actually delivered.
+        got: usize,
+    },
+    /// Record-array payload is not a positive multiple of the record size.
+    PayloadNotMultiple {
+        /// Command or reply code.
+        code: u8,
+        /// Per-record block size in bytes.
+        block: usize,
+        /// Bytes actually delivered.
+        got: usize,
+    },
     /// Multi-part receiver detected an invariant violation.
     Multipart(MultipartError),
     /// Secure-channel state machine rejected an event.
@@ -172,6 +199,28 @@ impl fmt::Display for Error {
             Error::UnknownReply(c) => write!(f, "unknown reply code: {c:#04x}"),
             Error::MalformedPayload { code, reason } => {
                 write!(f, "malformed payload for {code:#04x}: {reason}")
+            }
+            Error::PayloadLength {
+                code,
+                expected,
+                got,
+            } => {
+                write!(
+                    f,
+                    "payload length for {code:#04x}: expected {expected}, got {got}"
+                )
+            }
+            Error::PayloadTooShort { code, min, got } => {
+                write!(
+                    f,
+                    "payload for {code:#04x} too short: need at least {min}, got {got}"
+                )
+            }
+            Error::PayloadNotMultiple { code, block, got } => {
+                write!(
+                    f,
+                    "payload length for {code:#04x}: {got} is not a positive multiple of {block}"
+                )
             }
             Error::Multipart(e) => write!(f, "multipart: {e:?}"),
             Error::SecureSession(e) => write!(f, "secure session: {e:?}"),

--- a/src/error.rs
+++ b/src/error.rs
@@ -82,6 +82,15 @@ pub enum Error {
         /// Address echoed back in the reply.
         got: u8,
     },
+    /// Reply carried a sequence number we did not request. Per spec §5.7 /
+    /// Table 2 the PD must echo the ACU's SQN; a mismatch typically means a
+    /// stale reply from a desynchronised PD.
+    SqnMismatch {
+        /// SQN the ACU sent in the prompting command.
+        expected: u8,
+        /// SQN observed in the reply.
+        got: u8,
+    },
     /// PD answered with [`crate::reply::Nak`].
     Nak {
         /// Error code byte from the reply.
@@ -171,6 +180,9 @@ impl fmt::Display for Error {
             Error::Offline => f.write_str("PD declared off-line"),
             Error::AddrMismatch { sent, got } => {
                 write!(f, "address mismatch: sent {sent:#04x}, got {got:#04x}")
+            }
+            Error::SqnMismatch { expected, got } => {
+                write!(f, "SQN mismatch: expected {expected}, got {got}")
             }
             Error::Nak { code } => write!(f, "PD replied NAK ({code:#04x})"),
             Error::BufferOverflow { need, have } => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@
 //!
 //! # Layering
 //!
+//! See [`architecture`] for a rendered diagram of how these modules relate.
+//!
 //! - [`packet`] — wire framing (SOM, header, SCB, MAC, trailer)
 //! - [`command`] / [`reply`] — typed messages
 //! - [`multipart`] — RFC §5.10 multi-part assembly / disassembly
@@ -37,6 +39,39 @@ pub mod clock;
 pub mod error;
 pub mod packet;
 pub mod transport;
+
+/// Crate architecture diagram.
+///
+/// `osdp-rs` layers responsibilities so that the high-level state machines
+/// in [`driver`] can stay independent of the wire format and the I/O
+/// substrate. Every arrow points "uses".
+///
+#[cfg_attr(feature = "_docs", aquamarine::aquamarine)]
+/// ```mermaid
+/// flowchart TB
+///     APP([Application])
+///     subgraph drivers["driver — high-level state machines"]
+///         ACU[acu::Acu]
+///         PD[pd::Pd]
+///     end
+///     subgraph messages["typed messages"]
+///         CMD[command]
+///         REP[reply]
+///         MP[multipart]
+///     end
+///     subgraph wire["wire layer"]
+///         PKT[packet]
+///         SEC["secure (Annex D)"]
+///     end
+///     TR[transport]
+///     APP --> drivers
+///     drivers --> messages
+///     drivers --> wire
+///     drivers --> TR
+///     messages --> wire
+///     wire --> TR
+/// ```
+pub mod architecture {}
 
 #[cfg(feature = "alloc")]
 mod payload_util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,9 @@ pub mod packet;
 pub mod transport;
 
 #[cfg(feature = "alloc")]
+mod payload_util;
+
+#[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub mod command;
 #[cfg(feature = "alloc")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,36 @@
 //! - [`driver`] — ACU and PD state machines
 //! - [`caps`] — Annex B function codes
 //!
+//! # Quick start
+//!
+//! Drive a PD at address `0x05` through one POLL exchange. The example uses
+//! [`transport::VecTransport`], so without a peer feeding bytes back the
+//! exchange will end in [`driver::acu::ExchangeOutcome::Timeout`] — wire it
+//! up to a real `Transport` (or another `VecTransport`, see
+//! `examples/loopback_poll.rs`) for a successful round-trip.
+//!
+//! ```
+//! use osdp::clock::SystemClock;
+//! use osdp::command::{Command, Poll};
+//! use osdp::driver::acu::{Acu, ExchangeOutcome, PdState};
+//! use osdp::reply::Reply;
+//! use osdp::transport::VecTransport;
+//!
+//! let mut acu = Acu::new(VecTransport::new(), SystemClock::new());
+//! let mut pd = PdState::default();
+//! match acu.exchange(0x05, &mut pd, &Command::Poll(Poll))? {
+//!     ExchangeOutcome::Reply(Reply::Ack(_)) => { /* PD alive */ }
+//!     ExchangeOutcome::Busy => { /* PD asked us to back off */ }
+//!     ExchangeOutcome::Timeout => { /* no reply within budget */ }
+//!     ExchangeOutcome::Offline => { /* PD declared offline */ }
+//!     _ => {}
+//! }
+//! # Ok::<(), osdp::Error>(())
+//! ```
+//!
+//! For the secure-channel walk see `examples/handshake.rs`; for an end-to-end
+//! loopback that exercises SQN cycling see `examples/loopback_poll.rs`.
+//!
 //! # Specification cross-references
 //!
 //! All spec citations refer to *SIA OSDP v2.2* (©2020 Security Industry

--- a/src/multipart.rs
+++ b/src/multipart.rs
@@ -18,8 +18,32 @@
 //! - All fragments report the same `MpSizeTotal`.
 //! - Sender may abort by setting `MpOffset >= MpSizeTotal` and
 //!   `MpFragmentSize = 0`.
+//!
+//! See [`flow`] for a rendered fragment-exchange diagram.
 
 use crate::error::{Error, MultipartError};
+
+/// Rendered diagram of a multi-part transfer.
+///
+/// Each fragment is a normal OSDP packet whose data block is prefixed with a
+/// [`MultipartHeader`]. The receiver tracks the next-expected offset and
+/// rejects any out-of-order, overlapping, or total-changing fragment.
+///
+#[cfg_attr(feature = "_docs", aquamarine::aquamarine)]
+/// ```mermaid
+/// sequenceDiagram
+///     participant TX as MultipartTx<br/>(splitter)
+///     participant RX as MultipartRx<br/>(assembler)
+///     TX->>RX: hdr(total=N, offset=0,         frag=k₀) ‖ payload₀
+///     RX->>RX: state = AwaitOffset(k₀)
+///     TX->>RX: hdr(total=N, offset=k₀,        frag=k₁) ‖ payload₁
+///     RX->>RX: state = AwaitOffset(k₀+k₁)
+///     TX->>RX: hdr(total=N, offset=k₀+k₁,     frag=k₂) ‖ payload₂
+///     RX-->>TX: complete (reassembled body, N bytes)
+///     Note over TX,RX: TX may abort by sending<br/>hdr(total=N, offset≥N, frag=0)
+/// ```
+#[cfg(feature = "alloc")]
+pub mod flow {}
 
 /// Multi-part header on the wire.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/multipart.rs
+++ b/src/multipart.rs
@@ -106,6 +106,20 @@ mod alloc_impls {
         /// New splitter. `fragment_size` is the maximum payload size that
         /// fits into a single packet (excluding the 6-byte multi-part
         /// header).
+        ///
+        /// # Example
+        ///
+        /// ```
+        /// use osdp::multipart::{MultipartHeader, MultipartTx};
+        /// let body = b"hello, multi-part world";
+        /// let tx = MultipartTx::new(body, 8)?;
+        /// let parts: Vec<_> = tx.collect();
+        /// assert_eq!(parts.len(), 3);
+        /// assert_eq!(parts[0].0.total, body.len() as u16);
+        /// assert_eq!(parts[0].0.offset, 0);
+        /// assert_eq!(parts[0].1, &body[..8]);
+        /// # Ok::<(), osdp::Error>(())
+        /// ```
         pub fn new(body: &'a [u8], fragment_size: u16) -> Result<Self, Error> {
             if fragment_size == 0 {
                 return Err(Error::Multipart(MultipartError::BadFragmentSize));

--- a/src/packet/codec.rs
+++ b/src/packet/codec.rs
@@ -52,6 +52,22 @@ impl<'a> ParsedPacket<'a> {
     ///
     /// Returns the parsed packet view and the number of bytes consumed
     /// (which equals the value of the LEN field).
+    ///
+    /// The parser is total — every malformed input returns a typed
+    /// [`Error`] rather than panicking.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use osdp::packet::ParsedPacket;
+    /// // osdp_POLL frame addressed to PD 0x05, SQN=0, CRC-16/KERMIT trailer.
+    /// let bytes = [0x53, 0x05, 0x08, 0x00, 0x04, 0x60, 0xBC, 0x89];
+    /// let (parsed, used) = ParsedPacket::parse(&bytes)?;
+    /// assert_eq!(used, bytes.len());
+    /// assert_eq!(parsed.code, 0x60); // osdp_POLL
+    /// assert!(parsed.data.is_empty());
+    /// # Ok::<(), osdp::Error>(())
+    /// ```
     pub fn parse(buf: &'a [u8]) -> Result<(Self, usize), Error> {
         if buf.len() < HEADER_LEN {
             return Err(Error::Truncated {

--- a/src/payload_util.rs
+++ b/src/payload_util.rs
@@ -1,0 +1,64 @@
+//! Internal helpers for per-message encode/decode bodies. Centralizes the
+//! length validations that every payload module would otherwise duplicate.
+
+use crate::error::Error;
+
+/// Reject any payload whose length is not exactly `expected`.
+#[inline]
+pub(crate) fn require_exact_len(data: &[u8], expected: usize, code: u8) -> Result<(), Error> {
+    if data.len() != expected {
+        return Err(Error::PayloadLength {
+            code,
+            expected,
+            got: data.len(),
+        });
+    }
+    Ok(())
+}
+
+/// Reject any payload shorter than `min` (used when a header has variable-
+/// length tail and we need at least `min` bytes to parse the fixed prefix).
+#[inline]
+pub(crate) fn require_at_least(data: &[u8], min: usize, code: u8) -> Result<(), Error> {
+    if data.len() < min {
+        return Err(Error::PayloadTooShort {
+            code,
+            min,
+            got: data.len(),
+        });
+    }
+    Ok(())
+}
+
+/// Reject empty payloads or those whose length is not a multiple of `block`.
+/// Used by record-array commands like `osdp_OUT` and `osdp_LED` where each
+/// record is a fixed `block` bytes wide.
+#[inline]
+pub(crate) fn require_positive_multiple_of(
+    data: &[u8],
+    block: usize,
+    code: u8,
+) -> Result<(), Error> {
+    if data.is_empty() || data.len() % block != 0 {
+        return Err(Error::PayloadNotMultiple {
+            code,
+            block,
+            got: data.len(),
+        });
+    }
+    Ok(())
+}
+
+/// Reject payloads whose length is not a multiple of `block`. Empty payloads
+/// pass — used by lists like `osdp_PDCAP` where zero records is meaningful.
+#[inline]
+pub(crate) fn require_multiple_of(data: &[u8], block: usize, code: u8) -> Result<(), Error> {
+    if data.len() % block != 0 {
+        return Err(Error::PayloadNotMultiple {
+            code,
+            block,
+            got: data.len(),
+        });
+    }
+    Ok(())
+}

--- a/src/reply/ack.rs
+++ b/src/reply/ack.rs
@@ -26,3 +26,22 @@ impl Ack {
         Ok(Self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_empty() {
+        assert!(Ack.encode().unwrap().is_empty());
+        assert_eq!(Ack::decode(&[]).unwrap(), Ack);
+    }
+
+    #[test]
+    fn decode_rejects_payload() {
+        assert!(matches!(
+            Ack::decode(&[0x00]),
+            Err(Error::MalformedPayload { code: 0x40, .. })
+        ));
+    }
+}

--- a/src/reply/ack.rs
+++ b/src/reply/ack.rs
@@ -3,6 +3,7 @@
 //! # Spec: §7.1
 
 use crate::error::Error;
+use crate::payload_util::require_exact_len;
 use alloc::vec::Vec;
 
 /// `osdp_ACK` body.
@@ -17,12 +18,7 @@ impl Ack {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if !data.is_empty() {
-            return Err(Error::MalformedPayload {
-                code: 0x40,
-                reason: "ACK has no payload",
-            });
-        }
+        require_exact_len(data, 0, 0x40)?;
         Ok(Self)
     }
 }
@@ -41,7 +37,7 @@ mod tests {
     fn decode_rejects_payload() {
         assert!(matches!(
             Ack::decode(&[0x00]),
-            Err(Error::MalformedPayload { code: 0x40, .. })
+            Err(Error::PayloadLength { code: 0x40, .. })
         ));
     }
 }

--- a/src/reply/bio.rs
+++ b/src/reply/bio.rs
@@ -4,6 +4,7 @@
 
 use crate::command::{BioFormat, BioType};
 use crate::error::Error;
+use crate::payload_util::{require_at_least, require_exact_len};
 use alloc::vec::Vec;
 
 /// `osdp_BIOREADR` body.
@@ -42,12 +43,7 @@ impl BioReadR {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() < 6 {
-            return Err(Error::MalformedPayload {
-                code: 0x57,
-                reason: "BIOREADR requires at least 6 bytes",
-            });
-        }
+        require_at_least(data, 6, 0x57)?;
         let length = u16::from_le_bytes([data[4], data[5]]) as usize;
         if data.len() != 6 + length {
             return Err(Error::MalformedPayload {
@@ -84,12 +80,7 @@ impl BioMatchR {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() != 3 {
-            return Err(Error::MalformedPayload {
-                code: 0x58,
-                reason: "BIOMATCHR requires 3 bytes",
-            });
-        }
+        require_exact_len(data, 3, 0x58)?;
         Ok(Self {
             reader: data[0],
             result: data[1],
@@ -143,7 +134,7 @@ mod tests {
     fn biomatchr_rejects_wrong_length() {
         assert!(matches!(
             BioMatchR::decode(&[0x00, 0x01]),
-            Err(Error::MalformedPayload { code: 0x58, .. })
+            Err(Error::PayloadLength { code: 0x58, .. })
         ));
     }
 }

--- a/src/reply/bio.rs
+++ b/src/reply/bio.rs
@@ -97,3 +97,53 @@ impl BioMatchR {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bioreadr_roundtrip() {
+        let body = BioReadR {
+            reader: 0x01,
+            bio_type: BioType::RightThumb,
+            bio_format: BioFormat::FingerprintAnsi378,
+            quality: 90,
+            data: alloc::vec![0xDE, 0xAD],
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(
+            bytes,
+            [0x01, 0x01, 0x02, 90, 0x02, 0x00, 0xDE, 0xAD]
+        );
+        assert_eq!(BioReadR::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn bioreadr_rejects_length_mismatch() {
+        assert!(matches!(
+            BioReadR::decode(&[0x01, 0x01, 0x02, 90, 0x05, 0x00, 0xAA]),
+            Err(Error::MalformedPayload { code: 0x57, .. })
+        ));
+    }
+
+    #[test]
+    fn biomatchr_roundtrip() {
+        let body = BioMatchR {
+            reader: 0x00,
+            result: 0x01,
+            score: 95,
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0x00, 0x01, 95]);
+        assert_eq!(BioMatchR::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn biomatchr_rejects_wrong_length() {
+        assert!(matches!(
+            BioMatchR::decode(&[0x00, 0x01]),
+            Err(Error::MalformedPayload { code: 0x58, .. })
+        ));
+    }
+}

--- a/src/reply/bio.rs
+++ b/src/reply/bio.rs
@@ -103,10 +103,7 @@ mod tests {
             data: alloc::vec![0xDE, 0xAD],
         };
         let bytes = body.encode().unwrap();
-        assert_eq!(
-            bytes,
-            [0x01, 0x01, 0x02, 90, 0x02, 0x00, 0xDE, 0xAD]
-        );
+        assert_eq!(bytes, [0x01, 0x01, 0x02, 90, 0x02, 0x00, 0xDE, 0xAD]);
         assert_eq!(BioReadR::decode(&bytes).unwrap(), body);
     }
 

--- a/src/reply/busy.rs
+++ b/src/reply/busy.rs
@@ -26,3 +26,22 @@ impl Busy {
         Ok(Self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_empty() {
+        assert!(Busy.encode().unwrap().is_empty());
+        assert_eq!(Busy::decode(&[]).unwrap(), Busy);
+    }
+
+    #[test]
+    fn decode_rejects_payload() {
+        assert!(matches!(
+            Busy::decode(&[0xFF]),
+            Err(Error::MalformedPayload { code: 0x79, .. })
+        ));
+    }
+}

--- a/src/reply/busy.rs
+++ b/src/reply/busy.rs
@@ -3,6 +3,7 @@
 //! # Spec: §7.18
 
 use crate::error::Error;
+use crate::payload_util::require_exact_len;
 use alloc::vec::Vec;
 
 /// `osdp_BUSY` body.
@@ -17,12 +18,7 @@ impl Busy {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if !data.is_empty() {
-            return Err(Error::MalformedPayload {
-                code: 0x79,
-                reason: "BUSY has no payload",
-            });
-        }
+        require_exact_len(data, 0, 0x79)?;
         Ok(Self)
     }
 }
@@ -41,7 +37,7 @@ mod tests {
     fn decode_rejects_payload() {
         assert!(matches!(
             Busy::decode(&[0xFF]),
-            Err(Error::MalformedPayload { code: 0x79, .. })
+            Err(Error::PayloadLength { code: 0x79, .. })
         ));
     }
 }

--- a/src/reply/ccrypt.rs
+++ b/src/reply/ccrypt.rs
@@ -49,3 +49,31 @@ impl CCrypt {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let body = CCrypt {
+            cuid: [0xAA; 8],
+            rnd_b: [0xBB; 8],
+            client_cryptogram: [0xCC; 16],
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes.len(), 32);
+        assert_eq!(&bytes[..8], &[0xAA; 8]);
+        assert_eq!(&bytes[8..16], &[0xBB; 8]);
+        assert_eq!(&bytes[16..32], &[0xCC; 16]);
+        assert_eq!(CCrypt::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn decode_rejects_wrong_length() {
+        assert!(matches!(
+            CCrypt::decode(&[0; 31]),
+            Err(Error::MalformedPayload { code: 0x76, .. })
+        ));
+    }
+}

--- a/src/reply/ccrypt.rs
+++ b/src/reply/ccrypt.rs
@@ -5,6 +5,7 @@
 //! Body: `cUID (8) || RND.B (8) || ClientCryptogram (16)`.
 
 use crate::error::Error;
+use crate::payload_util::require_exact_len;
 use alloc::vec::Vec;
 
 /// `osdp_CCRYPT` body.
@@ -30,12 +31,7 @@ impl CCrypt {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() != 32 {
-            return Err(Error::MalformedPayload {
-                code: 0x76,
-                reason: "CCRYPT requires 32 bytes",
-            });
-        }
+        require_exact_len(data, 32, 0x76)?;
         let mut cuid = [0u8; 8];
         cuid.copy_from_slice(&data[..8]);
         let mut rnd_b = [0u8; 8];
@@ -73,7 +69,7 @@ mod tests {
     fn decode_rejects_wrong_length() {
         assert!(matches!(
             CCrypt::decode(&[0; 31]),
-            Err(Error::MalformedPayload { code: 0x76, .. })
+            Err(Error::PayloadLength { code: 0x76, .. })
         ));
     }
 }

--- a/src/reply/com.rs
+++ b/src/reply/com.rs
@@ -6,6 +6,7 @@
 //! `osdp_COMSET`.
 
 use crate::error::Error;
+use crate::payload_util::require_exact_len;
 use alloc::vec::Vec;
 
 /// `osdp_COM` body.
@@ -28,12 +29,7 @@ impl Com {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() != 5 {
-            return Err(Error::MalformedPayload {
-                code: 0x54,
-                reason: "COM requires 5 bytes",
-            });
-        }
+        require_exact_len(data, 5, 0x54)?;
         Ok(Self {
             address: data[0],
             baud: u32::from_le_bytes([data[1], data[2], data[3], data[4]]),
@@ -60,7 +56,7 @@ mod tests {
     fn decode_rejects_wrong_length() {
         assert!(matches!(
             Com::decode(&[0; 4]),
-            Err(Error::MalformedPayload { code: 0x54, .. })
+            Err(Error::PayloadLength { code: 0x54, .. })
         ));
     }
 }

--- a/src/reply/com.rs
+++ b/src/reply/com.rs
@@ -40,3 +40,27 @@ impl Com {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let body = Com {
+            address: 0x05,
+            baud: 9600,
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0x05, 0x80, 0x25, 0x00, 0x00]);
+        assert_eq!(Com::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn decode_rejects_wrong_length() {
+        assert!(matches!(
+            Com::decode(&[0; 4]),
+            Err(Error::MalformedPayload { code: 0x54, .. })
+        ));
+    }
+}

--- a/src/reply/crauth.rs
+++ b/src/reply/crauth.rs
@@ -25,3 +25,28 @@ impl CrAuthR {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let body = CrAuthR {
+            response: alloc::vec![0xDE, 0xAD, 0xBE, 0xEF],
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0xDE, 0xAD, 0xBE, 0xEF]);
+        assert_eq!(CrAuthR::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn empty_response_is_valid() {
+        assert_eq!(
+            CrAuthR::decode(&[]).unwrap(),
+            CrAuthR {
+                response: Vec::new()
+            }
+        );
+    }
+}

--- a/src/reply/ft_stat.rs
+++ b/src/reply/ft_stat.rs
@@ -47,3 +47,29 @@ impl FtStat {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let body = FtStat {
+            status: 0x01,
+            delay_ms: 0x0064,
+            preferred_size: 0x0100,
+            flags: 0x0003,
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0x01, 0x64, 0x00, 0x00, 0x01, 0x03, 0x00]);
+        assert_eq!(FtStat::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn decode_rejects_wrong_length() {
+        assert!(matches!(
+            FtStat::decode(&[0; 6]),
+            Err(Error::MalformedPayload { code: 0x7A, .. })
+        ));
+    }
+}

--- a/src/reply/ft_stat.rs
+++ b/src/reply/ft_stat.rs
@@ -5,6 +5,7 @@
 //! Body: `status (1) || delay (2 LE) || preferred_size (2 LE) || flags (2 LE)`.
 
 use crate::error::Error;
+use crate::payload_util::require_exact_len;
 use alloc::vec::Vec;
 
 /// `osdp_FTSTAT` body.
@@ -33,12 +34,7 @@ impl FtStat {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() != 7 {
-            return Err(Error::MalformedPayload {
-                code: 0x7A,
-                reason: "FTSTAT requires 7 bytes",
-            });
-        }
+        require_exact_len(data, 7, 0x7A)?;
         Ok(Self {
             status: data[0],
             delay_ms: u16::from_le_bytes([data[1], data[2]]),
@@ -69,7 +65,7 @@ mod tests {
     fn decode_rejects_wrong_length() {
         assert!(matches!(
             FtStat::decode(&[0; 6]),
-            Err(Error::MalformedPayload { code: 0x7A, .. })
+            Err(Error::PayloadLength { code: 0x7A, .. })
         ));
     }
 }

--- a/src/reply/genauth.rs
+++ b/src/reply/genauth.rs
@@ -25,3 +25,28 @@ impl GenAuthR {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let body = GenAuthR {
+            response: alloc::vec![0x7C, 0x02, 0x82, 0x00],
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0x7C, 0x02, 0x82, 0x00]);
+        assert_eq!(GenAuthR::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn empty_response_is_valid() {
+        assert_eq!(
+            GenAuthR::decode(&[]).unwrap(),
+            GenAuthR {
+                response: Vec::new()
+            }
+        );
+    }
+}

--- a/src/reply/istat.rs
+++ b/src/reply/istat.rs
@@ -44,9 +44,6 @@ mod tests {
 
     #[test]
     fn empty_inputs_is_valid() {
-        assert_eq!(
-            IStatR::decode(&[]).unwrap(),
-            IStatR { inputs: Vec::new() }
-        );
+        assert_eq!(IStatR::decode(&[]).unwrap(), IStatR { inputs: Vec::new() });
     }
 }

--- a/src/reply/istat.rs
+++ b/src/reply/istat.rs
@@ -27,3 +27,26 @@ impl IStatR {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let body = IStatR {
+            inputs: alloc::vec![0, 1, 0, 1],
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0, 1, 0, 1]);
+        assert_eq!(IStatR::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn empty_inputs_is_valid() {
+        assert_eq!(
+            IStatR::decode(&[]).unwrap(),
+            IStatR { inputs: Vec::new() }
+        );
+    }
+}

--- a/src/reply/keypad.rs
+++ b/src/reply/keypad.rs
@@ -54,3 +54,42 @@ impl Keypad {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let body = Keypad {
+            reader: 0x00,
+            digit_count: 3,
+            digits: alloc::vec![b'1', b'2', b'3'],
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0x00, 3, b'1', b'2', b'3']);
+        assert_eq!(Keypad::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn encode_rejects_count_disagreement() {
+        let body = Keypad {
+            reader: 0,
+            digit_count: 5, // claims 5
+            digits: alloc::vec![b'1', b'2'], // but only carries 2
+        };
+        assert!(matches!(
+            body.encode(),
+            Err(Error::MalformedPayload { code: 0x53, .. })
+        ));
+    }
+
+    #[test]
+    fn decode_rejects_count_disagreement() {
+        // count=4 but only 1 digit byte follows.
+        assert!(matches!(
+            Keypad::decode(&[0x00, 4, b'1']),
+            Err(Error::MalformedPayload { code: 0x53, .. })
+        ));
+    }
+}

--- a/src/reply/keypad.rs
+++ b/src/reply/keypad.rs
@@ -3,6 +3,7 @@
 //! # Spec: §7.12
 
 use crate::error::Error;
+use crate::payload_util::require_at_least;
 use alloc::vec::Vec;
 
 /// `osdp_KEYPAD` body.
@@ -34,12 +35,7 @@ impl Keypad {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() < 2 {
-            return Err(Error::MalformedPayload {
-                code: 0x53,
-                reason: "KEYPAD requires at least 2 bytes",
-            });
-        }
+        require_at_least(data, 2, 0x53)?;
         let digit_count = data[1];
         if data.len() != 2 + digit_count as usize {
             return Err(Error::MalformedPayload {

--- a/src/reply/keypad.rs
+++ b/src/reply/keypad.rs
@@ -71,7 +71,7 @@ mod tests {
     fn encode_rejects_count_disagreement() {
         let body = Keypad {
             reader: 0,
-            digit_count: 5, // claims 5
+            digit_count: 5,                  // claims 5
             digits: alloc::vec![b'1', b'2'], // but only carries 2
         };
         assert!(matches!(

--- a/src/reply/lstat.rs
+++ b/src/reply/lstat.rs
@@ -37,3 +37,27 @@ impl LStatR {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let body = LStatR {
+            tamper: 0,
+            power: 1,
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0, 1]);
+        assert_eq!(LStatR::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn decode_rejects_wrong_length() {
+        assert!(matches!(
+            LStatR::decode(&[0]),
+            Err(Error::MalformedPayload { code: 0x48, .. })
+        ));
+    }
+}

--- a/src/reply/lstat.rs
+++ b/src/reply/lstat.rs
@@ -6,6 +6,7 @@
 //! fault.
 
 use crate::error::Error;
+use crate::payload_util::require_exact_len;
 use alloc::vec::Vec;
 
 /// `osdp_LSTATR` body.
@@ -25,12 +26,7 @@ impl LStatR {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() != 2 {
-            return Err(Error::MalformedPayload {
-                code: 0x48,
-                reason: "LSTATR requires 2 bytes",
-            });
-        }
+        require_exact_len(data, 2, 0x48)?;
         Ok(Self {
             tamper: data[0],
             power: data[1],
@@ -57,7 +53,7 @@ mod tests {
     fn decode_rejects_wrong_length() {
         assert!(matches!(
             LStatR::decode(&[0]),
-            Err(Error::MalformedPayload { code: 0x48, .. })
+            Err(Error::PayloadLength { code: 0x48, .. })
         ));
     }
 }

--- a/src/reply/mfg.rs
+++ b/src/reply/mfg.rs
@@ -59,3 +59,65 @@ oui_plus_payload!(
     "`osdp_MFGERRR` body — manufacturer error reply."
 );
 oui_plus_payload!(MfgRep, 0x90, "`osdp_MFGREP` body — manufacturer reply.");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mfgstatr_roundtrip() {
+        let body = MfgStatR {
+            oui: [0x00, 0x06, 0x8E],
+            payload: alloc::vec![0x01, 0x02],
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0x00, 0x06, 0x8E, 0x01, 0x02]);
+        assert_eq!(MfgStatR::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn mfgstatr_rejects_short_oui() {
+        assert!(matches!(
+            MfgStatR::decode(&[0x00, 0x06]),
+            Err(Error::MalformedPayload { code: 0x83, .. })
+        ));
+    }
+
+    #[test]
+    fn mfgerrr_roundtrip() {
+        let body = MfgErrR {
+            oui: [0xAA, 0xBB, 0xCC],
+            payload: alloc::vec![0xEE],
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0xAA, 0xBB, 0xCC, 0xEE]);
+        assert_eq!(MfgErrR::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn mfgerrr_rejects_short_oui() {
+        assert!(matches!(
+            MfgErrR::decode(&[0xAA]),
+            Err(Error::MalformedPayload { code: 0x84, .. })
+        ));
+    }
+
+    #[test]
+    fn mfgrep_roundtrip_empty_payload() {
+        let body = MfgRep {
+            oui: [0x11, 0x22, 0x33],
+            payload: Vec::new(),
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0x11, 0x22, 0x33]);
+        assert_eq!(MfgRep::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn mfgrep_rejects_short_oui() {
+        assert!(matches!(
+            MfgRep::decode(&[]),
+            Err(Error::MalformedPayload { code: 0x90, .. })
+        ));
+    }
+}

--- a/src/reply/mfg.rs
+++ b/src/reply/mfg.rs
@@ -7,6 +7,7 @@
 //! - `osdp_MFGREP` (`0x90`) — vendor reply (OUI + payload).
 
 use crate::error::Error;
+use crate::payload_util::require_at_least;
 use alloc::vec::Vec;
 
 macro_rules! oui_plus_payload {
@@ -31,12 +32,7 @@ macro_rules! oui_plus_payload {
 
             /// Decode.
             pub fn decode(data: &[u8]) -> Result<Self, Error> {
-                if data.len() < 3 {
-                    return Err(Error::MalformedPayload {
-                        code: $code,
-                        reason: "manufacturer reply requires 3-byte OUI",
-                    });
-                }
+                require_at_least(data, 3, $code)?;
                 let mut oui = [0u8; 3];
                 oui.copy_from_slice(&data[..3]);
                 Ok(Self {
@@ -79,7 +75,7 @@ mod tests {
     fn mfgstatr_rejects_short_oui() {
         assert!(matches!(
             MfgStatR::decode(&[0x00, 0x06]),
-            Err(Error::MalformedPayload { code: 0x83, .. })
+            Err(Error::PayloadTooShort { code: 0x83, .. })
         ));
     }
 
@@ -98,7 +94,7 @@ mod tests {
     fn mfgerrr_rejects_short_oui() {
         assert!(matches!(
             MfgErrR::decode(&[0xAA]),
-            Err(Error::MalformedPayload { code: 0x84, .. })
+            Err(Error::PayloadTooShort { code: 0x84, .. })
         ));
     }
 
@@ -117,7 +113,7 @@ mod tests {
     fn mfgrep_rejects_short_oui() {
         assert!(matches!(
             MfgRep::decode(&[]),
-            Err(Error::MalformedPayload { code: 0x90, .. })
+            Err(Error::PayloadTooShort { code: 0x90, .. })
         ));
     }
 }

--- a/src/reply/nak.rs
+++ b/src/reply/nak.rs
@@ -6,6 +6,7 @@
 //! completion-code array (only when error code is `0x09`).
 
 use crate::error::Error;
+use crate::payload_util::require_at_least;
 use alloc::vec::Vec;
 
 /// NAK error code (Table 47).
@@ -84,12 +85,7 @@ impl Nak {
     /// silently dropping the byte (NAK arriving with an unknown code is
     /// usually a sign of bus chaos worth surfacing).
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.is_empty() {
-            return Err(Error::MalformedPayload {
-                code: 0x41,
-                reason: "NAK requires at least 1 byte",
-            });
-        }
+        require_at_least(data, 1, 0x41)?;
         let error = NakErrorCode::from_byte(data[0])?;
         let completion_codes = if error == NakErrorCode::UnableToProcessCommandRecord {
             data[1..].to_vec()

--- a/src/reply/ostat.rs
+++ b/src/reply/ostat.rs
@@ -27,3 +27,28 @@ impl OStatR {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let body = OStatR {
+            outputs: alloc::vec![1, 0, 1, 0],
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [1, 0, 1, 0]);
+        assert_eq!(OStatR::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn empty_outputs_is_valid() {
+        assert_eq!(
+            OStatR::decode(&[]).unwrap(),
+            OStatR {
+                outputs: Vec::new()
+            }
+        );
+    }
+}

--- a/src/reply/pdcap.rs
+++ b/src/reply/pdcap.rs
@@ -6,6 +6,7 @@
 
 use crate::caps::{Capability, FunctionCode};
 use crate::error::Error;
+use crate::payload_util::require_multiple_of;
 use alloc::vec::Vec;
 
 /// `osdp_PDCAP` body.
@@ -40,12 +41,7 @@ impl PdCap {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() % Capability::WIRE_LEN != 0 {
-            return Err(Error::MalformedPayload {
-                code: 0x46,
-                reason: "PDCAP payload must be multiple of 3 bytes",
-            });
-        }
+        require_multiple_of(data, Capability::WIRE_LEN, 0x46)?;
         let capabilities = data
             .chunks_exact(Capability::WIRE_LEN)
             .map(|c| Capability::decode([c[0], c[1], c[2]]))

--- a/src/reply/pdid.rs
+++ b/src/reply/pdid.rs
@@ -12,6 +12,7 @@
 //! ```
 
 use crate::error::Error;
+use crate::payload_util::require_exact_len;
 use alloc::vec::Vec;
 
 /// `osdp_PDID` body.
@@ -46,12 +47,7 @@ impl PdId {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() != Self::WIRE_LEN {
-            return Err(Error::MalformedPayload {
-                code: 0x45,
-                reason: "PDID requires 12 bytes",
-            });
-        }
+        require_exact_len(data, Self::WIRE_LEN, 0x45)?;
         let mut vendor_oui = [0u8; 3];
         vendor_oui.copy_from_slice(&data[..3]);
         let mut firmware = [0u8; 3];

--- a/src/reply/piv.rs
+++ b/src/reply/piv.rs
@@ -25,3 +25,26 @@ impl PivDataR {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let body = PivDataR {
+            data: alloc::vec![0xDE, 0xAD, 0xBE, 0xEF],
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0xDE, 0xAD, 0xBE, 0xEF]);
+        assert_eq!(PivDataR::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn empty_payload_is_valid() {
+        assert_eq!(
+            PivDataR::decode(&[]).unwrap(),
+            PivDataR { data: Vec::new() }
+        );
+    }
+}

--- a/src/reply/raw_card.rs
+++ b/src/reply/raw_card.rs
@@ -8,6 +8,7 @@
 //! be ignored.
 
 use crate::error::Error;
+use crate::payload_util::require_at_least;
 use alloc::vec::Vec;
 
 /// `osdp_RAW` body.
@@ -43,12 +44,7 @@ impl Raw {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() < 4 {
-            return Err(Error::MalformedPayload {
-                code: 0x50,
-                reason: "RAW requires at least 4 bytes",
-            });
-        }
+        require_at_least(data, 4, 0x50)?;
         let bit_count = u16::from_le_bytes([data[2], data[3]]);
         let need = (bit_count as usize).div_ceil(8);
         if data.len() != 4 + need {
@@ -117,12 +113,7 @@ impl Fmt {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() < 3 {
-            return Err(Error::MalformedPayload {
-                code: 0x51,
-                reason: "FMT requires at least 3 bytes",
-            });
-        }
+        require_at_least(data, 3, 0x51)?;
         let char_count = data[2];
         if data.len() != 3 + char_count as usize {
             return Err(Error::MalformedPayload {

--- a/src/reply/rmac_i.rs
+++ b/src/reply/rmac_i.rs
@@ -3,6 +3,7 @@
 //! # Spec: §7.17, Annex D.4
 
 use crate::error::Error;
+use crate::payload_util::require_exact_len;
 use alloc::vec::Vec;
 
 /// `osdp_RMAC_I` body.
@@ -20,12 +21,7 @@ impl RMacI {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() != 16 {
-            return Err(Error::MalformedPayload {
-                code: 0x78,
-                reason: "RMAC_I requires 16 bytes",
-            });
-        }
+        require_exact_len(data, 16, 0x78)?;
         let mut r_mac_i = [0u8; 16];
         r_mac_i.copy_from_slice(data);
         Ok(Self { r_mac_i })
@@ -50,7 +46,7 @@ mod tests {
     fn decode_rejects_wrong_length() {
         assert!(matches!(
             RMacI::decode(&[0; 15]),
-            Err(Error::MalformedPayload { code: 0x78, .. })
+            Err(Error::PayloadLength { code: 0x78, .. })
         ));
     }
 }

--- a/src/reply/rmac_i.rs
+++ b/src/reply/rmac_i.rs
@@ -31,3 +31,26 @@ impl RMacI {
         Ok(Self { r_mac_i })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let body = RMacI {
+            r_mac_i: [0x77; 16],
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes.len(), 16);
+        assert_eq!(RMacI::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn decode_rejects_wrong_length() {
+        assert!(matches!(
+            RMacI::decode(&[0; 15]),
+            Err(Error::MalformedPayload { code: 0x78, .. })
+        ));
+    }
+}

--- a/src/reply/rstat.rs
+++ b/src/reply/rstat.rs
@@ -27,3 +27,28 @@ impl RStatR {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let body = RStatR {
+            readers: alloc::vec![0, 1, 2],
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0, 1, 2]);
+        assert_eq!(RStatR::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn empty_readers_is_valid() {
+        assert_eq!(
+            RStatR::decode(&[]).unwrap(),
+            RStatR {
+                readers: Vec::new()
+            }
+        );
+    }
+}

--- a/src/reply/xrd.rs
+++ b/src/reply/xrd.rs
@@ -6,6 +6,7 @@
 //! mode-specific.
 
 use crate::error::Error;
+use crate::payload_util::require_at_least;
 use alloc::vec::Vec;
 
 /// `osdp_XRD` body — opaque container.
@@ -28,12 +29,7 @@ impl Xrd {
 
     /// Decode.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.is_empty() {
-            return Err(Error::MalformedPayload {
-                code: 0xB1,
-                reason: "XRD requires XRW_MODE byte",
-            });
-        }
+        require_at_least(data, 1, 0xB1)?;
         Ok(Self {
             mode: data[0],
             payload: data[1..].to_vec(),
@@ -71,7 +67,7 @@ mod tests {
     fn empty_decode_rejected() {
         assert!(matches!(
             Xrd::decode(&[]),
-            Err(Error::MalformedPayload { code: 0xB1, .. })
+            Err(Error::PayloadTooShort { code: 0xB1, .. })
         ));
     }
 }

--- a/src/reply/xrd.rs
+++ b/src/reply/xrd.rs
@@ -40,3 +40,38 @@ impl Xrd {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let body = Xrd {
+            mode: 0x01,
+            payload: alloc::vec![0xCA, 0xFE],
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0x01, 0xCA, 0xFE]);
+        assert_eq!(Xrd::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn mode_only_is_valid() {
+        let body = Xrd {
+            mode: 0x00,
+            payload: Vec::new(),
+        };
+        let bytes = body.encode().unwrap();
+        assert_eq!(bytes, [0x00]);
+        assert_eq!(Xrd::decode(&bytes).unwrap(), body);
+    }
+
+    #[test]
+    fn empty_decode_rejected() {
+        assert!(matches!(
+            Xrd::decode(&[]),
+            Err(Error::MalformedPayload { code: 0xB1, .. })
+        ));
+    }
+}

--- a/src/secure/crypto.rs
+++ b/src/secure/crypto.rs
@@ -53,7 +53,7 @@ fn key_template(tag1: u8, tag2: u8, rnd_a: &[u8; 8]) -> Block {
 }
 
 /// Derived session keys.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct SessionKeys {
     /// `S-ENC` — encryption key.
     pub s_enc: [u8; 16],

--- a/src/secure/crypto.rs
+++ b/src/secure/crypto.rs
@@ -17,6 +17,7 @@
 use aes::Aes128;
 use aes::cipher::generic_array::GenericArray;
 use aes::cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// 128-bit AES block.
 pub type Block = [u8; 16];
@@ -53,7 +54,10 @@ fn key_template(tag1: u8, tag2: u8, rnd_a: &[u8; 8]) -> Block {
 }
 
 /// Derived session keys.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+///
+/// Zeroized on drop so cancelled or panicking sessions don't leave key
+/// material in heap or stack memory.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Zeroize, ZeroizeOnDrop)]
 pub struct SessionKeys {
     /// `S-ENC` — encryption key.
     pub s_enc: [u8; 16],

--- a/src/secure/frame.rs
+++ b/src/secure/frame.rs
@@ -62,8 +62,8 @@ pub fn seal(
     };
     builder.encode_with_mac(|bytes| {
         let full = session.mac(bytes);
-        let mut tag = [0u8; 4];
-        tag.copy_from_slice(&full[..4]);
+        let mut tag = [0u8; crate::packet::MAC_LEN];
+        tag.copy_from_slice(&full[..crate::packet::MAC_LEN]);
         tag
     })
 }

--- a/src/secure/mod.rs
+++ b/src/secure/mod.rs
@@ -8,7 +8,8 @@
 //! 2. [`mac`] — CBC-MAC with the S-MAC1/S-MAC2 swap on the final block.
 //! 3. [`session`] — type-state machine wrapping the above into a usable API.
 //!
-//! Padding is described in [`pad`].
+//! Padding is described in [`pad`]. The full handshake is rendered in
+//! [`handshake`].
 
 pub mod cipher;
 pub mod crypto;
@@ -16,6 +17,33 @@ pub mod frame;
 pub mod mac;
 pub mod pad;
 pub mod session;
+
+/// Annex D.4 secure-channel handshake.
+///
+/// Both sides start out sharing only the SCBK (out-of-band install key, or a
+/// previously-keyset session key). The handshake derives matching session
+/// keys, proves possession to each end, and seeds the rolling-ICV chain that
+/// every subsequent SCS_15..=18 frame uses.
+///
+#[cfg_attr(feature = "_docs", aquamarine::aquamarine)]
+/// ```mermaid
+/// sequenceDiagram
+///     participant ACU
+///     participant PD
+///     Note over ACU,PD: Both share SCBK out-of-band
+///     ACU->>PD: osdp_CHLNG (RND.A)
+///     PD->>PD: derive S-ENC, S-MAC1, S-MAC2 from SCBK ⊕ RND.A
+///     PD->>PD: pick RND.B; compute ClientCryptogram
+///     PD->>ACU: osdp_CCRYPT (cUID, RND.B, ClientCryptogram)
+///     ACU->>ACU: derive same keys; verify ClientCryptogram
+///     ACU->>ACU: compute ServerCryptogram
+///     ACU->>PD: osdp_SCRYPT (ServerCryptogram)
+///     PD->>PD: verify ServerCryptogram; compute initial R-MAC
+///     PD->>ACU: osdp_RMAC_I (initial R-MAC)
+///     ACU->>ACU: verify R-MAC matches own
+///     Note over ACU,PD: Session is Secure;<br/>SCS_15..=18 frames carry rolling ICV
+/// ```
+pub mod handshake {}
 
 pub use frame::{Direction, seal, unseal};
 pub use session::{Challenged, Cryptogrammed, Disconnected, Secure, Session};

--- a/src/secure/session.rs
+++ b/src/secure/session.rs
@@ -3,15 +3,10 @@
 //! # Spec: Annex D.4
 //!
 //! States are phantom-typed so that calling out-of-order is a *compile* error
-//! rather than a runtime fault. The intended sequence is:
+//! rather than a runtime fault. Calls from any state may transition back to
+//! [`Disconnected`] on error.
 //!
-//! ```text
-//! Disconnected --challenge(RND.A)----> Challenged
-//! Challenged   --recv_ccrypt(...)----> Cryptogrammed
-//! Cryptogrammed--recv_rmac_i(...)----> Secure
-//! ```
-//!
-//! Calls from any state may transition back to [`Disconnected`] on error.
+//! See [`Session`] for the rendered state diagram.
 
 use crate::error::SecureSessionError;
 use crate::reply::CCrypt;
@@ -35,6 +30,23 @@ pub struct Cryptogrammed;
 pub struct Secure;
 
 /// Secure-channel session state.
+///
+/// The phantom parameter `S` tracks which step of the Annex D.4 handshake
+/// the session is in. Each transition consumes the old `Session` and yields
+/// a new one in the next state — calling methods out of order is therefore a
+/// *compile* error rather than a runtime fault.
+///
+#[cfg_attr(feature = "_docs", aquamarine::aquamarine)]
+/// ```mermaid
+/// stateDiagram-v2
+///     [*] --> Disconnected: Session::new(scbk)
+///     Disconnected --> Challenged: challenge(RND.A)
+///     Challenged --> Cryptogrammed: receive_ccrypt(ccrypt) ✔
+///     Challenged --> Disconnected: receive_ccrypt(ccrypt) ✘<br/>BadCryptogram
+///     Cryptogrammed --> Secure: confirm_rmac_i(mac) ✔
+///     Cryptogrammed --> Disconnected: confirm_rmac_i(mac) ✘<br/>BadCryptogram
+///     Secure --> Secure: mac() / verify()<br/>seal_data() / open_data()
+/// ```
 ///
 /// All fields are zeroized when the session is dropped (regardless of which
 /// state it is in), so cancelled or panicking flows do not leave the SCBK or

--- a/src/secure/session.rs
+++ b/src/secure/session.rs
@@ -186,7 +186,11 @@ impl Session<Secure> {
             &self.keys.s_mac1,
             &self.keys.s_mac2,
         );
-        if computed[..crate::packet::MAC_LEN].ct_eq(wire_mac).unwrap_u8() == 0 {
+        if computed[..crate::packet::MAC_LEN]
+            .ct_eq(wire_mac)
+            .unwrap_u8()
+            == 0
+        {
             return Err(SecureSessionError::BadCryptogram);
         }
         self.last_their_mac = computed;

--- a/src/secure/session.rs
+++ b/src/secure/session.rs
@@ -106,6 +106,16 @@ impl<S> Session<S> {
 
 impl Session<Disconnected> {
     /// Begin a new session, holding the SCBK we will use.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use osdp::secure::{SCBK_D, Session};
+    /// use osdp::secure::session::Disconnected;
+    /// let session = Session::<Disconnected>::new(SCBK_D);
+    /// // The next step is `session.challenge(rnd_a)` once we've sent osdp_CHLNG.
+    /// # let _ = session;
+    /// ```
     pub fn new(scbk: [u8; 16]) -> Self {
         Self {
             scbk,

--- a/src/secure/session.rs
+++ b/src/secure/session.rs
@@ -47,27 +47,10 @@ pub struct Session<S> {
     _state: PhantomData<S>,
 }
 
-impl Session<Disconnected> {
-    /// Begin a new session, holding the SCBK we will use.
-    pub fn new(scbk: [u8; 16]) -> Self {
-        Self {
-            scbk,
-            rnd_a: [0; 8],
-            rnd_b: [0; 8],
-            cuid: [0; 8],
-            keys: SessionKeys {
-                s_enc: [0; 16],
-                s_mac1: [0; 16],
-                s_mac2: [0; 16],
-            },
-            last_their_mac: [0; 16],
-            _state: PhantomData,
-        }
-    }
-
-    /// Move to [`Challenged`] by capturing the `RND.A` we are about to send.
-    pub fn challenge(mut self, rnd_a: [u8; 8]) -> Session<Challenged> {
-        self.rnd_a = rnd_a;
+impl<S> Session<S> {
+    /// Carry every field forward into a new phantom state. Used for
+    /// state transitions that do not mutate cryptographic material.
+    fn transition<T>(self) -> Session<T> {
         Session {
             scbk: self.scbk,
             rnd_a: self.rnd_a,
@@ -77,6 +60,41 @@ impl Session<Disconnected> {
             last_their_mac: self.last_their_mac,
             _state: PhantomData,
         }
+    }
+
+    /// Drop back to [`Disconnected`], wiping all derived material but keeping
+    /// the SCBK so the caller can immediately re-handshake.
+    fn reset(self) -> Session<Disconnected> {
+        Session {
+            scbk: self.scbk,
+            rnd_a: [0; 8],
+            rnd_b: [0; 8],
+            cuid: [0; 8],
+            keys: SessionKeys::default(),
+            last_their_mac: [0; 16],
+            _state: PhantomData,
+        }
+    }
+}
+
+impl Session<Disconnected> {
+    /// Begin a new session, holding the SCBK we will use.
+    pub fn new(scbk: [u8; 16]) -> Self {
+        Self {
+            scbk,
+            rnd_a: [0; 8],
+            rnd_b: [0; 8],
+            cuid: [0; 8],
+            keys: SessionKeys::default(),
+            last_their_mac: [0; 16],
+            _state: PhantomData,
+        }
+    }
+
+    /// Move to [`Challenged`] by capturing the `RND.A` we are about to send.
+    pub fn challenge(mut self, rnd_a: [u8; 8]) -> Session<Challenged> {
+        self.rnd_a = rnd_a;
+        self.transition()
     }
 }
 
@@ -91,33 +109,9 @@ impl Session<Challenged> {
         self.keys = SessionKeys::derive(&self.scbk, &self.rnd_a);
         let expected = client_cryptogram(&self.keys.s_enc, &self.rnd_a, &self.rnd_b);
         if expected.ct_eq(&ccrypt.client_cryptogram).unwrap_u8() == 0 {
-            return Err((self.into_disconnected(), SecureSessionError::BadCryptogram));
+            return Err((self.reset(), SecureSessionError::BadCryptogram));
         }
-        Ok(Session {
-            scbk: self.scbk,
-            rnd_a: self.rnd_a,
-            rnd_b: self.rnd_b,
-            cuid: self.cuid,
-            keys: self.keys,
-            last_their_mac: self.last_their_mac,
-            _state: PhantomData,
-        })
-    }
-
-    fn into_disconnected(self) -> Session<Disconnected> {
-        Session {
-            scbk: self.scbk,
-            rnd_a: [0; 8],
-            rnd_b: [0; 8],
-            cuid: [0; 8],
-            keys: SessionKeys {
-                s_enc: [0; 16],
-                s_mac1: [0; 16],
-                s_mac2: [0; 16],
-            },
-            last_their_mac: [0; 16],
-            _state: PhantomData,
-        }
+        Ok(self.transition())
     }
 }
 
@@ -138,39 +132,15 @@ impl Session<Cryptogrammed> {
 
     /// PD echoed back our initial R-MAC; advance to fully [`Secure`].
     pub fn confirm_rmac_i(
-        self,
+        mut self,
         their_rmac_i: &[u8; 16],
     ) -> Result<Session<Secure>, (Session<Disconnected>, SecureSessionError)> {
         let mine = self.initial_rmac();
         if mine.ct_eq(their_rmac_i).unwrap_u8() == 0 {
-            let mut me = self;
-            me.last_their_mac = [0; 16];
-            return Err((
-                Session {
-                    scbk: me.scbk,
-                    rnd_a: [0; 8],
-                    rnd_b: [0; 8],
-                    cuid: [0; 8],
-                    keys: SessionKeys {
-                        s_enc: [0; 16],
-                        s_mac1: [0; 16],
-                        s_mac2: [0; 16],
-                    },
-                    last_their_mac: [0; 16],
-                    _state: PhantomData,
-                },
-                SecureSessionError::BadCryptogram,
-            ));
+            return Err((self.reset(), SecureSessionError::BadCryptogram));
         }
-        Ok(Session {
-            scbk: self.scbk,
-            rnd_a: self.rnd_a,
-            rnd_b: self.rnd_b,
-            cuid: self.cuid,
-            keys: self.keys,
-            last_their_mac: mine,
-            _state: PhantomData,
-        })
+        self.last_their_mac = mine;
+        Ok(self.transition())
     }
 }
 

--- a/src/secure/session.rs
+++ b/src/secure/session.rs
@@ -160,14 +160,18 @@ impl Session<Secure> {
     }
 
     /// Verify a received MAC against our locally-computed value.
-    pub fn verify(&mut self, bytes: &[u8], wire_mac: &[u8; 4]) -> Result<(), SecureSessionError> {
+    pub fn verify(
+        &mut self,
+        bytes: &[u8],
+        wire_mac: &[u8; crate::packet::MAC_LEN],
+    ) -> Result<(), SecureSessionError> {
         let computed = cbc_mac(
             bytes,
             &self.last_their_mac,
             &self.keys.s_mac1,
             &self.keys.s_mac2,
         );
-        if computed[..4].ct_eq(wire_mac).unwrap_u8() == 0 {
+        if computed[..crate::packet::MAC_LEN].ct_eq(wire_mac).unwrap_u8() == 0 {
             return Err(SecureSessionError::BadCryptogram);
         }
         self.last_their_mac = computed;

--- a/src/secure/session.rs
+++ b/src/secure/session.rs
@@ -19,6 +19,7 @@ use crate::secure::crypto::{SessionKeys, client_cryptogram, initial_rmac, server
 use crate::secure::mac::cbc_mac;
 use core::marker::PhantomData;
 use subtle::ConstantTimeEq;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// Phantom: session not started.
 #[derive(Debug, Clone, Copy)]
@@ -34,7 +35,14 @@ pub struct Cryptogrammed;
 pub struct Secure;
 
 /// Secure-channel session state.
-#[derive(Debug, Clone)]
+///
+/// All fields are zeroized when the session is dropped (regardless of which
+/// state it is in), so cancelled or panicking flows do not leave the SCBK or
+/// derived material in memory. Note that `Clone` is preserved for ergonomic
+/// fork-and-mirror flows: cloning duplicates the key material, and only the
+/// dropped clone is zeroized — the surviving clone still holds keys until it
+/// is dropped in turn.
+#[derive(Debug, Clone, Zeroize, ZeroizeOnDrop)]
 pub struct Session<S> {
     scbk: [u8; 16],
     rnd_a: [u8; 8],
@@ -44,29 +52,36 @@ pub struct Session<S> {
     /// Last MAC received from the *other* device — used as ICV for the next
     /// outgoing MAC, per Annex D.5.
     last_their_mac: [u8; 16],
+    #[zeroize(skip)]
     _state: PhantomData<S>,
 }
 
 impl<S> Session<S> {
     /// Carry every field forward into a new phantom state. Used for
     /// state transitions that do not mutate cryptographic material.
-    fn transition<T>(self) -> Session<T> {
+    ///
+    /// Uses `core::mem::take` per field rather than direct moves because
+    /// `Session` derives `ZeroizeOnDrop`, which adds a `Drop` impl and
+    /// forbids moving out of fields. Each `take` leaves a zero in `self`,
+    /// the new `Session` carries the original value, and the old `self` is
+    /// then dropped (zeroizing already-zero memory — a no-op).
+    fn transition<T>(mut self) -> Session<T> {
         Session {
-            scbk: self.scbk,
-            rnd_a: self.rnd_a,
-            rnd_b: self.rnd_b,
-            cuid: self.cuid,
-            keys: self.keys,
-            last_their_mac: self.last_their_mac,
+            scbk: core::mem::take(&mut self.scbk),
+            rnd_a: core::mem::take(&mut self.rnd_a),
+            rnd_b: core::mem::take(&mut self.rnd_b),
+            cuid: core::mem::take(&mut self.cuid),
+            keys: core::mem::take(&mut self.keys),
+            last_their_mac: core::mem::take(&mut self.last_their_mac),
             _state: PhantomData,
         }
     }
 
     /// Drop back to [`Disconnected`], wiping all derived material but keeping
     /// the SCBK so the caller can immediately re-handshake.
-    fn reset(self) -> Session<Disconnected> {
+    fn reset(mut self) -> Session<Disconnected> {
         Session {
-            scbk: self.scbk,
+            scbk: core::mem::take(&mut self.scbk),
             rnd_a: [0; 8],
             rnd_b: [0; 8],
             cuid: [0; 8],

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -62,6 +62,13 @@ impl VecTransport {
         let v: alloc::vec::Vec<u8> = self.outgoing.drain(..).collect();
         v
     }
+
+    /// Move every byte from this transport's outgoing queue into `other`'s
+    /// incoming queue, modelling a one-way half-duplex bus segment. Useful in
+    /// loopback tests and examples that wire two `VecTransport`s back-to-back.
+    pub fn shuffle_to(&mut self, other: &mut VecTransport) {
+        other.incoming.extend(self.outgoing.drain(..));
+    }
 }
 
 #[cfg(feature = "alloc")]

--- a/tests/chaos_bus.rs
+++ b/tests/chaos_bus.rs
@@ -12,36 +12,19 @@
 //!   the PD off-line within 8 s of simulated time rather than spinning
 //!   forever.
 
+mod common;
+
+use common::{AlwaysAck, Lcg};
 use osdp::clock::MockClock;
 use osdp::command::{Command, Poll};
 use osdp::driver::acu::{Acu, ExchangeOutcome, PdState, RetryConfig};
-use osdp::driver::pd::{Pd, PdHandler};
-use osdp::reply::{Ack, Reply};
+use osdp::driver::pd::Pd;
+use osdp::reply::Reply;
 use osdp::transport::VecTransport;
 
 extern crate alloc;
 use alloc::collections::VecDeque;
 use alloc::vec::Vec;
-
-/// A tiny LCG so tests don't need a real RNG crate.
-#[derive(Debug, Clone)]
-struct Lcg(u64);
-impl Lcg {
-    fn new(seed: u64) -> Self {
-        Self(seed | 1)
-    }
-    fn next_u32(&mut self) -> u32 {
-        self.0 = self
-            .0
-            .wrapping_mul(6364136223846793005)
-            .wrapping_add(1442695040888963407);
-        (self.0 >> 32) as u32
-    }
-    /// Uniform 0..1 step.
-    fn next_unit(&mut self) -> f64 {
-        (self.next_u32() as f64) / (u32::MAX as f64)
-    }
-}
 
 /// Per-byte chaos parameters.
 #[derive(Debug, Clone, Copy)]
@@ -83,13 +66,6 @@ impl Middleman {
             }
         }
         out
-    }
-}
-
-struct AlwaysAck;
-impl PdHandler for AlwaysAck {
-    fn on_command(&mut self, _command: &Command) -> Reply {
-        Reply::Ack(Ack)
     }
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,44 @@
+//! Helpers shared between integration tests in `tests/`.
+//!
+//! Cargo's "tests/common/mod.rs" convention keeps this from being compiled as
+//! its own integration-test binary. Each test that needs a helper does
+//! `mod common;` (and `#[allow(dead_code)]` to silence warnings about helpers
+//! that one specific test happens not to use).
+
+#![allow(dead_code)]
+
+use osdp::command::Command;
+use osdp::driver::pd::PdHandler;
+use osdp::reply::{Ack, Reply};
+
+/// PD handler that answers every command with `osdp_ACK`.
+pub struct AlwaysAck;
+
+impl PdHandler for AlwaysAck {
+    fn on_command(&mut self, _command: &Command) -> Reply {
+        Reply::Ack(Ack)
+    }
+}
+
+/// Tiny LCG used by chaos-bus tests so we don't need a real RNG crate.
+#[derive(Debug, Clone)]
+pub struct Lcg(u64);
+
+impl Lcg {
+    pub fn new(seed: u64) -> Self {
+        Self(seed | 1)
+    }
+
+    pub fn next_u32(&mut self) -> u32 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        (self.0 >> 32) as u32
+    }
+
+    /// Uniform draw in `0.0..=1.0`.
+    pub fn next_unit(&mut self) -> f64 {
+        (self.next_u32() as f64) / (u32::MAX as f64)
+    }
+}

--- a/tests/loopback.rs
+++ b/tests/loopback.rs
@@ -32,12 +32,6 @@ impl PdHandler for LoopbackPd {
     }
 }
 
-/// Ferry bytes from one end's outgoing to the other end's incoming.
-fn shuffle(from: &mut VecTransport, to: &mut VecTransport) {
-    let bytes: Vec<u8> = from.outgoing.drain(..).collect();
-    to.incoming.extend(bytes);
-}
-
 #[test]
 fn poll_then_id_round_trip() {
     let acu_port = VecTransport::new();
@@ -51,12 +45,12 @@ fn poll_then_id_round_trip() {
 
     // ACU sends POLL.
     acu.send_to(0x05, &mut state, &Command::Poll(Poll)).unwrap();
-    shuffle(acu.transport(), pd.transport());
+    acu.transport().shuffle_to(pd.transport());
 
     // PD processes and replies.
     let processed = pd.poll_once().unwrap();
     assert!(processed);
-    shuffle(pd.transport(), acu.transport());
+    pd.transport().shuffle_to(acu.transport());
 
     // ACU receives ACK.
     let reply = acu.receive(&mut state).unwrap();
@@ -66,9 +60,9 @@ fn poll_then_id_round_trip() {
     // ACU now sends ID.
     acu.send_to(0x05, &mut state, &Command::Id(Id::standard()))
         .unwrap();
-    shuffle(acu.transport(), pd.transport());
+    acu.transport().shuffle_to(pd.transport());
     pd.poll_once().unwrap();
-    shuffle(pd.transport(), acu.transport());
+    pd.transport().shuffle_to(acu.transport());
 
     let reply = acu.receive(&mut state).unwrap();
     match reply {
@@ -93,9 +87,9 @@ fn pd_repeats_reply_on_duplicate_sqn() {
 
     // First exchange.
     acu.send_to(0x07, &mut state, &Command::Poll(Poll)).unwrap();
-    shuffle(acu.transport(), pd.transport());
+    acu.transport().shuffle_to(pd.transport());
     pd.poll_once().unwrap();
-    shuffle(pd.transport(), acu.transport());
+    pd.transport().shuffle_to(acu.transport());
     let _ = acu.receive(&mut state).unwrap();
 
     // ACU "loses" the reply and asks again with the same SQN. We force
@@ -103,7 +97,7 @@ fn pd_repeats_reply_on_duplicate_sqn() {
     state.next_sqn = osdp::Sqn::new(0).unwrap();
 
     let bytes_first = acu.send_to(0x07, &mut state, &Command::Poll(Poll)).unwrap();
-    shuffle(acu.transport(), pd.transport());
+    acu.transport().shuffle_to(pd.transport());
     pd.poll_once().unwrap();
 
     let pd_outgoing: Vec<u8> = pd.transport().outgoing.drain(..).collect();


### PR DESCRIPTION
Localized hygiene pass over the v0.2.x rewrite. Thirteen commits, ordered low-risk first.

### Refactor & cleanup

1. **`refactor(secure)`** — dedupe `Session<S>` state-transition boilerplate via `transition<T>`/`reset` helpers and a `Default` impl on `SessionKeys`.
2. **`refactor(driver)`** — extract a single `recv_loop` shared by `receive` and `recv_one_with_sqn`; promote `MAX_EMPTY_READS`, `RX_CHUNK_LEN`, and `MAC_LEN` reuse to named constants.
3. **`feat(driver)`** — wire up the previously-unused `_expected_sqn`: enforce §5.7 / Table 2 SQN echo, with `osdp_BUSY` exempt (always SQN=0 per Annex A.2). Adds `Error::SqnMismatch` and two regression tests.
4. **`refactor(tests)`** — share `AlwaysAck` and the toy `Lcg` RNG via `tests/common/mod.rs`; promote the duplicated `shuffle()` helper to a `VecTransport::shuffle_to` method usable from both tests and examples.
5. **`test(command)` / `test(reply)`** — encode-asserts-bytes / decode-asserts-struct round-trips and a rejection test for every command and reply body that lacked them (35 modules, ~60 new tests).
6. **`refactor`** — replace stringly-typed `MalformedPayload { reason: "X requires N bytes" }` patterns with three typed `Error` variants (`PayloadLength` / `PayloadTooShort` / `PayloadNotMultiple`) and four `payload_util` helpers; migrated ~30 sites. `Error` is `non_exhaustive` so this is non-breaking.
7. **`feat(secure)`** — derive `Zeroize`/`ZeroizeOnDrop` on `Session<S>` and `SessionKeys` so cancelled or panicking sessions don't leak SCBK or derived keys; switched the state-transition helpers to `core::mem::take` since `Drop` forbids field moves.
8. **`style: cargo fmt`**.

### Docs

9. **`docs`** — add `[package.metadata.docs.rs]` (`all-features = true`, `--cfg docsrs`) so docs.rs ships the secure-channel API, plus a private `_docs` feature that pulls in `aquamarine 0.6` for rustdoc-rendered Mermaid.
10. **`docs(diagrams)`** — Mermaid for the four core state machines: `Session<S>` type-state, ACU `exchange` flow, multipart fragment exchange, full Annex D.4 handshake sequence. Plus a crate-root `architecture` flowchart.
11. **`docs(readme)`** — same architecture + handshake diagrams in the README (GitHub renders Mermaid natively); refreshed stale unit-test count and the `secure-channel` feature row to include `zeroize`.
12. **`docs`** — runnable doctests for the README quick-start (in `lib.rs`), `ParsedPacket::parse` (with a real CRC trailer), `MultipartTx::new`, and `Session::<Disconnected>::new`.

Net: 191 tests (was 85). `cargo test --all-features`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`, no-default-feature builds, doc build, both examples — all green. No MSRV change.