### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0](https://github.com/Quantumlyy/osdp-rs/compare/v0.2.1...v0.3.0) - 2026-05-05
+
+### Added
+
+- *(secure)* Zeroize Session and SessionKeys on drop
+- *(driver)* Enforce SQN echo per spec table 2
+
+### Changed
+
+- Replace stringly-typed length errors with typed variants
+- *(tests)* Share helpers via tests/common, add VecTransport::shuffle_to
+- *(driver)* Dedupe ACU receive loop, name magic numbers
+- *(secure)* Dedupe Session<S> state-transition boilerplate
+
+### Documentation
+
+- Drop Session:: qualifier from handshake state diagram
+- Add runnable doctests for the high-traffic public APIs
+- *(readme)* Add architecture + handshake diagrams; refresh stale stats
+- Add mermaid diagrams for the four core state machines
+- Wire up aquamarine + docs.rs metadata
+
+### Testing
+
+- *(reply)* Add unit tests for every reply body
+- *(command)* Add unit tests for every command body
+
 ## [0.2.1](https://github.com/Quantumlyy/osdp-rs/compare/v0.2.0...v0.2.1) - 2026-05-04
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "osdp"
-version = "0.2.1"
+version = "0.3.0"
 description = "Pure-Rust, no_std-friendly implementation of the SIA Open Supervised Device Protocol (OSDP) v2.2"
 license = "BSD-3-Clause"
 homepage = "https://github.com/Quantumlyy/osdp-rs/blob/main/README.md"


### PR DESCRIPTION



## 🤖 New release

* `osdp`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `osdp` breaking changes

```text
--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type SessionKeys no longer derives Copy, in /tmp/.tmpkGiMLw/osdp-rs/src/secure/crypto.rs:61
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/Quantumlyy/osdp-rs/compare/v0.2.1...v0.3.0) - 2026-05-05

### Added

- *(secure)* Zeroize Session and SessionKeys on drop
- *(driver)* Enforce SQN echo per spec table 2

### Changed

- Replace stringly-typed length errors with typed variants
- *(tests)* Share helpers via tests/common, add VecTransport::shuffle_to
- *(driver)* Dedupe ACU receive loop, name magic numbers
- *(secure)* Dedupe Session<S> state-transition boilerplate

### Documentation

- Drop Session:: qualifier from handshake state diagram
- Add runnable doctests for the high-traffic public APIs
- *(readme)* Add architecture + handshake diagrams; refresh stale stats
- Add mermaid diagrams for the four core state machines
- Wire up aquamarine + docs.rs metadata

### Testing

- *(reply)* Add unit tests for every reply body
- *(command)* Add unit tests for every command body
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).