### PR TITLE
docs: fix GitHub Mermaid render error in handshake state diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The Annex D.4 secure-channel handshake is fully type-stated:
 
 ```mermaid
 stateDiagram-v2
-    [*] --> Disconnected: Session::new(scbk)
+    [*] --> Disconnected: new(scbk)
     Disconnected --> Challenged: challenge(RND.A)
     Challenged --> Cryptogrammed: receive_ccrypt(ccrypt) ✔
     Challenged --> Disconnected: receive_ccrypt(ccrypt) ✘

--- a/src/secure/session.rs
+++ b/src/secure/session.rs
@@ -39,7 +39,7 @@ pub struct Secure;
 #[cfg_attr(feature = "_docs", aquamarine::aquamarine)]
 /// ```mermaid
 /// stateDiagram-v2
-///     [*] --> Disconnected: Session::new(scbk)
+///     [*] --> Disconnected: new(scbk)
 ///     Disconnected --> Challenged: challenge(RND.A)
 ///     Challenged --> Cryptogrammed: receive_ccrypt(ccrypt) ✔
 ///     Challenged --> Disconnected: receive_ccrypt(ccrypt) ✘<br/>BadCryptogram


### PR DESCRIPTION
## Summary

GitHub's Mermaid renderer was rejecting the Annex D.4 handshake `stateDiagram-v2` block in the README with a parse error pointing past `Session::new(scbk)`. Root cause: `stateDiagram-v2` lexes `::` as the `STYLE_SEPARATOR` token (used for `state X::className` class assignments), which corrupts the transition's description and bleeds the parser into the next line.

Drop the `Session::` qualifier so the label reads `new(scbk)` — consistent with the other unqualified transition labels (`challenge(RND.A)`, `receive_ccrypt(ccrypt)`, `confirm_rmac_i(mac)`, ...) and unambiguous in a diagram already scoped to `Session<S>`. Applied to both the README copy and the rustdoc copy on `Session<S>` in `src/secure/session.rs`.